### PR TITLE
Deprecated `isEncrypted` property in Metadata

### DIFF
--- a/at_commons/lib/src/at_constants.dart
+++ b/at_commons/lib/src/at_constants.dart
@@ -40,6 +40,7 @@ const String UPDATE_JSON = 'update:json';
 const String VALUE = 'value';
 const String UPDATE_ALL = 'all';
 const String CCD = 'ccd';
+const String PUBLIC = 'public';
 const String CACHED = 'cached';
 const String REFRESH_AT = 'refreshAt';
 const String IS_BINARY = 'isBinary';

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -110,8 +110,9 @@ class AtKey {
       atKey.key = keyParts[0].split('@')[0];
     } else {
       // Example key: public:phone@bob
-      if (keyParts[0] == 'public') {
+      if (keyParts[0] == PUBLIC) {
         metaData.isPublic = true;
+        metaData.isEncrypted = false;
       }
       // Example key: cached:@alice:phone@bob
       else if (keyParts[0] == CACHED) {
@@ -153,6 +154,7 @@ class PublicKey extends AtKey {
   PublicKey() {
     super.metadata = Metadata();
     super.metadata!.isPublic = true;
+    super.metadata!.isEncrypted = false;
   }
 }
 
@@ -190,11 +192,13 @@ class Metadata {
   DateTime? updatedAt;
   String? dataSignature;
   String? sharedKeyStatus;
-  bool? isPublic = false;
+  bool isPublic = false;
   bool isHidden = false;
   bool namespaceAware = true;
   bool? isBinary = false;
-  bool? isEncrypted;
+  @Deprecated(
+      'As of every key-values are encrypted by default, this is no longer required.  It\'s value is always true')
+  bool isEncrypted = true;
   bool isCached = false;
 
   @override

--- a/at_commons/lib/src/keystore/at_key_builder_impl.dart
+++ b/at_commons/lib/src/keystore/at_key_builder_impl.dart
@@ -68,6 +68,7 @@ class PublicKeyBuilder extends CachedKeyBuilder {
     _atKey = PublicKey();
     _meta.isPublic = true;
     _meta.isHidden = false;
+    _meta.isEncrypted = false;
   }
 
   @override

--- a/at_commons/test/at_key_test.dart
+++ b/at_commons/test/at_key_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/src/keystore/at_key_builder_impl.dart';
 import 'package:test/expect.dart';
@@ -10,6 +12,7 @@ void main() {
       expect(atKey.key, 'phone');
       expect(atKey.sharedBy, 'bob');
       expect(atKey.metadata!.isPublic, true);
+      expect(atKey.metadata!.isEncrypted, false);
       expect(atKey.metadata!.namespaceAware, false);
     });
 
@@ -94,6 +97,7 @@ void main() {
     test('Test to verify the public key', () {
       AtKey atKey = AtKey.public('phone', namespace: 'wavi').build();
       expect(atKey, isA<PublicKey>());
+      expect(atKey.metadata?.isEncrypted, false);
     });
 
     test('Test to verify the shared key', () {
@@ -149,6 +153,7 @@ void main() {
       expect(atKey.metadata!.ttl, equals(null));
       expect(atKey.metadata!.ttb, equals(null));
       expect(atKey.metadata!.isPublic, equals(true));
+      expect(atKey.metadata!.isEncrypted, equals(false));
       expect(atKey.metadata!.isBinary, equals(false));
       expect(atKey.metadata!.isCached, equals(false));
     });
@@ -164,7 +169,7 @@ void main() {
       expect(atKey.metadata!.ttl, equals(1000));
       expect(atKey.metadata!.ttb, equals(2000));
       expect(atKey.metadata!.isPublic, equals(true));
-      expect(atKey.metadata!.isPublic, equals(true));
+      expect(atKey.metadata!.isEncrypted, equals(false));
       expect(atKey.metadata!.isBinary, equals(false));
       expect(atKey.metadata!.isCached, equals(false));
     });
@@ -181,6 +186,7 @@ void main() {
       expect(atKey.metadata!.ttl, equals(null));
       expect(atKey.metadata!.ttb, equals(null));
       expect(atKey.metadata!.isPublic, equals(false));
+      expect(atKey.metadata!.isEncrypted, equals(true));
       expect(atKey.metadata!.isBinary, equals(false));
       expect(atKey.metadata!.isCached, equals(false));
     });
@@ -199,6 +205,7 @@ void main() {
       expect(atKey.metadata!.ttl, equals(null));
       expect(atKey.metadata!.ttb, equals(null));
       expect(atKey.metadata!.isPublic, equals(false));
+      expect(atKey.metadata!.isEncrypted, equals(true));
       expect(atKey.metadata!.isBinary, equals(false));
       expect(atKey.metadata!.isCached, equals(true));
     });


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Deprecated `isEncrypted` property for the AtKey metadata.

**- How I did it**
- Writing up the `@Deprecated()` above the property.

**- How to verify it**
- remove the isEncrypted property from your keys and test it.

**Additional content**
- Regarding https://github.com/atsign-foundation/at_client_sdk/issues/365