### PR TITLE
Rename TimeoutException to AtTimeoutException

### DIFF
--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.5
+- Rename TimeoutException to AtTimeoutException to prevent confusion with Dart async's TimeoutException
 ## 3.0.4
 - Add TimeoutException
 ## 3.0.3

--- a/at_commons/lib/src/exception/at_exceptions.dart
+++ b/at_commons/lib/src/exception/at_exceptions.dart
@@ -1,4 +1,5 @@
 class AtException implements Exception {
+  // ignore: prefer_typing_uninitialized_variables
   var message;
 
   AtException(this.message);
@@ -115,6 +116,6 @@ class IllegalArgumentException extends AtException {
 }
 
 /// Throws when no response is received before timeout duration
-class TimeoutException extends AtException {
-  TimeoutException(message) : super(message);
+class AtTimeoutException extends AtException {
+  AtTimeoutException(message) : super(message);
 }

--- a/at_commons/lib/src/exception/error_message.dart
+++ b/at_commons/lib/src/exception/error_message.dart
@@ -1,3 +1,4 @@
+// ignore: constant_identifier_names
 const Map error_codes = {
   'AtServerException': 'AT0001',
   'DataStoreException': 'AT0002',
@@ -17,9 +18,10 @@ const Map error_codes = {
   'KeyNotFoundException': 'AT0015',
   'SecondaryConnectException': 'AT0021',
   'IllegalArgumentException': 'AT0022',
-  'TimeoutException': 'AT0023'
+  'AtTimeoutException': 'AT0023'
 };
 
+// ignore: constant_identifier_names
 const Map error_description = {
   'AT0001': 'Server exception',
   'AT0002': 'DataStore exception',

--- a/at_commons/pubspec.yaml
+++ b/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the @‎platform.
-version: 3.0.4
+version: 3.0.5
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 


### PR DESCRIPTION
**- Description for the changelog**
Rename TimeoutException to AtTimeoutException to prevent confusion with Dart async's TimeoutException
