### PR TITLE
at_cli: ran dart pub upgrade --major-dependencies, rebuilt, upped version to 3.0.0

### DIFF
--- a/at_cli/pubspec.yaml
+++ b/at_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_cli
 description: A command line utility for at protocol commands.
-version: 2.0.0
+version: 3.0.0
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 
@@ -9,8 +9,8 @@ environment:
 
 dependencies:
   args: ^2.1.1
-  at_lookup: ^2.0.4
-  at_client: ^2.0.3
+  at_lookup: ^3.0.7
+  at_client: ^3.0.9
   crypton: ^2.0.1
   encrypt: ^5.0.0
 


### PR DESCRIPTION
For at_cli: Ran dart pub upgrade --major-dependencies; updated at_cli version to 3.0.0
Fixes #149 


**- To verify**
Checkout, run dart pub get, then dart compile exe bin/main.dart -o ~/at_cli should compile OK

**- Description for the changelog**
For at_cli: Ran dart pub upgrade --major-dependencies; updated at_cli version to 3.0.0
