### PR TITLE
Info and noop verbs

### DIFF
--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.6
+- Added syntax regexes for new verbs 'info' and 'noop'
 ## 3.0.5
 - Rename TimeoutException to AtTimeoutException to prevent confusion with Dart async's TimeoutException
 ## 3.0.4

--- a/at_commons/lib/src/buffer/at_buffer.dart
+++ b/at_commons/lib/src/buffer/at_buffer.dart
@@ -9,6 +9,7 @@ abstract class AtBuffer<T> {
   int? capacity;
 
   /// Define terminatingChar to indicate end of buffer
+  // ignore: prefer_typing_uninitialized_variables
   var terminatingChar;
 
   /// Returns the message stored in the buffer

--- a/at_commons/lib/src/compaction/at_compaction_config.dart
+++ b/at_commons/lib/src/compaction/at_compaction_config.dart
@@ -8,13 +8,7 @@ class AtCompactionConfig {
   // Frequency interval in which the logs are compacted
   int? compactionFrequencyMins;
 
-  AtCompactionConfig(int sizeInKB, int timeInDays, int compactionPercentage,
-      int compactionFrequencyMins) {
-    this.sizeInKB = sizeInKB;
-    this.timeInDays = timeInDays;
-    this.compactionPercentage = compactionPercentage;
-    this.compactionFrequencyMins = compactionFrequencyMins;
-  }
+  AtCompactionConfig(this.sizeInKB, this.timeInDays, this.compactionPercentage, this.compactionFrequencyMins);
 
   bool timeBasedCompaction() {
     return timeInDays != -1;

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -120,13 +120,13 @@ class AtKey {
       } else {
         atKey.sharedWith = keyParts[0];
       }
-      var keyArr;
+      List<String> keyArr = [];
       if (keyParts[0] == CACHED) {
         keyArr = keyParts[2].split('@');
       } else {
         keyArr = keyParts[1].split('@');
       }
-      if (keyArr != null && keyArr.length == 2) {
+      if (keyArr.length == 2) {
         atKey.sharedBy = keyArr[1];
         atKey.key = keyArr[0];
       } else {

--- a/at_commons/lib/src/verb/config_verb_builder.dart
+++ b/at_commons/lib/src/verb/config_verb_builder.dart
@@ -21,8 +21,9 @@ class ConfigVerbBuilder implements VerbBuilder {
       command += '$operation:';
     }
     if (atSigns != null && atSigns!.isNotEmpty) {
-      atSigns!
-          .forEach((atSign) => command += '${VerbUtil.formatAtSign(atSign)}');
+      for (var atSign in atSigns!) {
+        command += '${VerbUtil.formatAtSign(atSign)}';
+      }
     }
     command = command.trim();
     command = command + '\n';

--- a/at_commons/lib/src/verb/delete_verb_builder.dart
+++ b/at_commons/lib/src/verb/delete_verb_builder.dart
@@ -1,6 +1,5 @@
 import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/src/verb/verb_builder.dart';
-import 'package:at_commons/src/verb/verb_util.dart';
 
 /// Delete verb builder generates a command to delete a [atKey] from the secondary server.
 /// ```

--- a/at_commons/lib/src/verb/notify_all_verb_builder.dart
+++ b/at_commons/lib/src/verb/notify_all_verb_builder.dart
@@ -1,6 +1,5 @@
 import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/src/verb/verb_builder.dart';
-import 'package:at_commons/src/verb/verb_util.dart';
 
 class NotifyAllVerbBuilder implements VerbBuilder {
   /// Key that represents a user's information. e.g phone, location, email etc.,

--- a/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -1,6 +1,5 @@
 import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/src/verb/verb_builder.dart';
-import 'package:at_commons/src/verb/verb_util.dart';
 
 class NotifyVerbBuilder implements VerbBuilder {
   /// Key that represents a user's information. e.g phone, location, email etc.,

--- a/at_commons/lib/src/verb/plookup_verb_builder.dart
+++ b/at_commons/lib/src/verb/plookup_verb_builder.dart
@@ -19,7 +19,7 @@ class PLookupVerbBuilder implements VerbBuilder {
 
   @override
   String buildCommand() {
-    var command;
+    String command;
     if (operation != null) {
       command = 'plookup:$operation:$atKey${VerbUtil.formatAtSign(sharedBy)}\n';
     } else {

--- a/at_commons/lib/src/verb/response.dart
+++ b/at_commons/lib/src/verb/response.dart
@@ -1,20 +1,17 @@
 import 'package:at_commons/at_commons.dart';
 
 class Response {
-  String? _data;
-  String? _type;
-  bool _isError = false;
-  String? _errorMessage;
+  String? data;
+  String? type;
+  bool isError = false;
+  String? errorMessage;
   String? errorCode;
   AtException? atException;
-
-  bool get isError => _isError;
-
   bool isStream = false;
 
   Response();
 
-  Response.factory(this._data, this.errorCode, this._errorMessage);
+  Response.factory(this.data, this.errorCode, this.errorMessage);
 
   factory Response.fromJson(dynamic json) {
     return Response.factory(json['data'] as String?,
@@ -23,42 +20,20 @@ class Response {
 
   Map toJson() {
     var jsonMap = {};
-    if (_data != null) {
-      jsonMap['data'] = _data;
+    if (data != null) {
+      jsonMap['data'] = data;
     }
     if (errorCode != null) {
       jsonMap['error_code'] = errorCode;
     }
-    if (_errorMessage != null) {
-      jsonMap['error_message'] = _errorMessage;
+    if (errorMessage != null) {
+      jsonMap['error_message'] = errorMessage;
     }
     return jsonMap;
   }
 
   @override
   String toString() {
-    return 'Response{_data: $_data, _type: $_type, _isError: $_isError, _errorMessage: $_errorMessage}';
-  }
-
-  set isError(bool value) {
-    _isError = value;
-  }
-
-  String? get errorMessage => _errorMessage;
-
-  set errorMessage(String? value) {
-    _errorMessage = value;
-  }
-
-  String? get type => _type;
-
-  set type(String? value) {
-    _type = value;
-  }
-
-  String? get data => _data;
-
-  set data(String? value) {
-    _data = value;
+    return 'Response{_data: $data, _type: $type, _isError: $isError, _errorMessage: $errorMessage}';
   }
 }

--- a/at_commons/lib/src/verb/sync_verb_builder.dart
+++ b/at_commons/lib/src/verb/sync_verb_builder.dart
@@ -1,7 +1,7 @@
 import 'package:at_commons/at_builders.dart';
 
 class SyncVerbBuilder implements VerbBuilder {
-  late var commitId;
+  late int commitId;
 
   String? regex;
 

--- a/at_commons/lib/src/verb/syntax.dart
+++ b/at_commons/lib/src/verb/syntax.dart
@@ -37,5 +37,5 @@ class VerbSyntax {
       r'^notify:all:((?<operation>update|delete):)?(messageType:((?<messageType>key|text):))?(?:ttl:(?<ttl>\d+):)?(?:ttb:(?<ttb>\d+):)?(?:ttr:(?<ttr>-?\d+):)?(?:ccd:(?<ccd>true|false+):)?(?<forAtSign>(([^:\s])+)?(,([^:\s]+))*)(:(?<atKey>[^@:\s]+))(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
   static const batch = r'^batch:(?<json>.+)$';
   static const info = r'^info$';
-  static const noop = r'^noop:(?<delayMillis>\d+)$';
+  static const noOp = r'^noop:(?<delayMillis>\d+)$';
 }

--- a/at_commons/lib/src/verb/syntax.dart
+++ b/at_commons/lib/src/verb/syntax.dart
@@ -20,6 +20,7 @@ class VerbSyntax {
       r'^sync:from:(?<from_commit_seq>[0-9]+|-1)(:limit:(?<limit>\d+))(:(?<regex>.+))?$';
   static const update =
       r'^update:json:(?<json>.+)$|^update:(?:ttl:(?<ttl>\d+):)?(?:ttb:(?<ttb>\d+):)?(?:ttr:(?<ttr>(-?)\d+):)?(ccd:(?<ccd>true|false):)?(?:dataSignature:(?<dataSignature>[^:@]+):)?(?:sharedKeyStatus:(?<sharedKeyStatus>[^:@]+):)?(isBinary:(?<isBinary>true|false):)?(isEncrypted:(?<isEncrypted>true|false):)?(priority:(?<priority>low|medium|high):)?((?:public:)|(@(?<forAtSign>[^@:\s]*):))?(?<atKey>[^:@]((?!:{2})[^@])+)(?:@(?<atSign>[^@\s]*))? (?<value>.+$)';
+  // ignore: constant_identifier_names
   static const update_meta =
       r'^update:meta:((?:public:)|((?<forAtSign>@?[^@\s]*):))?(?<atKey>((?!:{2})[^@])+)@(?<atSign>[^@:\s]*)(:ttl:(?<ttl>\d+))?(:ttb:(?<ttb>\d+))?(:ttr:(?<ttr>\d+))?(:ccd:(?<ccd>true|false))?(?:sharedKeyStatus:(?<sharedKeyStatus>[^:@]+):)?(:isBinary:(?<isBinary>true|false))?(:isEncrypted:(?<isEncrypted>true|false))?$';
   static const delete =
@@ -35,4 +36,6 @@ class VerbSyntax {
   static const notifyAll =
       r'^notify:all:((?<operation>update|delete):)?(messageType:((?<messageType>key|text):))?(?:ttl:(?<ttl>\d+):)?(?:ttb:(?<ttb>\d+):)?(?:ttr:(?<ttr>-?\d+):)?(?:ccd:(?<ccd>true|false+):)?(?<forAtSign>(([^:\s])+)?(,([^:\s]+))*)(:(?<atKey>[^@:\s]+))(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
   static const batch = r'^batch:(?<json>.+)$';
+  static const info = r'^info$';
+  static const noop = r'^noop:(?<delayMillis>\d+)$';
 }

--- a/at_commons/lib/src/verb/update_verb_builder.dart
+++ b/at_commons/lib/src/verb/update_verb_builder.dart
@@ -1,8 +1,8 @@
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/src/verb/verb_builder.dart';
-import 'package:at_commons/src/verb/verb_util.dart';
 
 /// Update builder generates a command to update [value] for a key [atKey] in the secondary server of [sharedBy].
 /// Use [getBuilder] method if you want to convert command to a builder.
@@ -173,7 +173,7 @@ class UpdateVerbBuilder implements VerbBuilder {
 
   static UpdateVerbBuilder? getBuilder(String command) {
     var builder = UpdateVerbBuilder();
-    var verbParams;
+    HashMap<String, String?>? verbParams;
     if (command.contains(UPDATE_META)) {
       verbParams = VerbUtil.getVerbParam(VerbSyntax.update_meta, command);
       builder.operation = UPDATE_META;
@@ -191,20 +191,26 @@ class UpdateVerbBuilder implements VerbBuilder {
     if (builder.value is String) {
       builder.value = VerbUtil.replaceNewline(builder.value);
     }
-    if (verbParams[AT_TTL] != null) builder.ttl = int.parse(verbParams[AT_TTL]);
-    if (verbParams[AT_TTB] != null) builder.ttb = int.parse(verbParams[AT_TTB]);
-    if (verbParams[AT_TTR] != null) builder.ttr = int.parse(verbParams[AT_TTR]);
+    if (verbParams[AT_TTL] != null) {
+      builder.ttl = int.parse(verbParams[AT_TTL]!);
+    }
+    if (verbParams[AT_TTB] != null) {
+      builder.ttb = int.parse(verbParams[AT_TTB]!);
+    }
+    if (verbParams[AT_TTR] != null) {
+      builder.ttr = int.parse(verbParams[AT_TTR]!);
+    }
     if (verbParams[CCD] != null) {
-      builder.ccd = _getBoolVerbParams(verbParams[CCD]);
+      builder.ccd = _getBoolVerbParams(verbParams[CCD]!);
     }
     if (verbParams[PUBLIC_DATA_SIGNATURE] != null) {
       builder.dataSignature = verbParams[PUBLIC_DATA_SIGNATURE];
     }
     if (verbParams[IS_BINARY] != null) {
-      builder.isBinary = _getBoolVerbParams(verbParams[IS_BINARY]);
+      builder.isBinary = _getBoolVerbParams(verbParams[IS_BINARY]!);
     }
     if (verbParams[IS_ENCRYPTED] != null) {
-      builder.isEncrypted = _getBoolVerbParams(verbParams[IS_ENCRYPTED]);
+      builder.isEncrypted = _getBoolVerbParams(verbParams[IS_ENCRYPTED]!);
     }
     return builder;
   }

--- a/at_commons/lib/src/verb/verb_util.dart
+++ b/at_commons/lib/src/verb/verb_util.dart
@@ -1,7 +1,7 @@
 import 'dart:collection';
 
 class VerbUtil {
-  static const String NEW_LINE_REPLACE_PATTERN = '~NL~';
+  static const String newLineReplacePattern = '~NL~';
   static Iterable<RegExpMatch> _getMatches(RegExp regex, String command) {
     var matches = regex.allMatches(command);
     return matches;
@@ -10,11 +10,11 @@ class VerbUtil {
   static HashMap<String, String?> _processMatches(
       Iterable<RegExpMatch> matches) {
     var paramsMap = HashMap<String, String?>();
-    matches.forEach((f) {
+    for (var f in matches) {
       for (var name in f.groupNames) {
         paramsMap.putIfAbsent(name, () => f.namedGroup(name));
       }
-    });
+    }
     return paramsMap;
   }
 
@@ -36,10 +36,10 @@ class VerbUtil {
   }
 
   static String replaceNewline(String value) {
-    return value.replaceAll('\n', NEW_LINE_REPLACE_PATTERN);
+    return value.replaceAll('\n', newLineReplacePattern);
   }
 
   static String getFormattedValue(String value) {
-    return value.replaceAll(NEW_LINE_REPLACE_PATTERN, '\n');
+    return value.replaceAll(newLineReplacePattern, '\n');
   }
 }

--- a/at_commons/pubspec.yaml
+++ b/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the @‎platform.
-version: 3.0.5
+version: 3.0.6
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/at_commons/test/sync_verb_builder_test.dart
+++ b/at_commons/test/sync_verb_builder_test.dart
@@ -1,5 +1,4 @@
 import 'package:at_commons/at_builders.dart';
-import 'package:at_commons/src/verb/sync_verb_builder.dart';
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
**- What I did**
* Added regexes for new verbs 'info' and 'noop' to lib/src/verb/syntax.dart
* Cleaned up lint warnings. Most of these are trivial; a couple weren't, but are safe:
  * lib/src/verb/response.dart : four private instance variables had standard getters and setters, thus making those variables _de facto_ not private at all; renamed those private vars (removing the _ prefix) and removed the getters and setters
  * lib/src/verb/verb_util.dart : Renamed static string constant from NEW_LINE_REPLACE_PATTERN to newLineReplacePattern. Verified safe by searching for usages across all code in [atsign-foundation](https://github.com/search?q=org%3Aatsign-foundation+NEW_LINE_REPLACE_PATTERN) and [atsign-company](https://github.com/search?q=org%3Aatsign-company+NEW_LINE_REPLACE_PATTERN); no usages found except in this file.

**- Description for the changelog**
* Added regexes for new verbs 'info' and 'noop' to lib/src/verb/syntax.dart
