### PR TITLE
shared key metadata support in notify

### DIFF
--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.8
+- Support for encryption shared key and public key in notify verb
 ## 3.0.7
 - Added encryption shared key and public key checksum to metadata
 ## 3.0.6

--- a/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -50,6 +50,12 @@ class NotifyVerbBuilder implements VerbBuilder {
 
   bool? ccd;
 
+  /// Will be set only when [sharedWith] is set. Will be encrypted using the public key of [sharedWith] atsign
+  String? sharedKeyEncrypted;
+
+  /// checksum of the the public key of [sharedWith] atsign. Will be set only when [sharedWith] is set.
+  String? pubKeyChecksum;
+
   @override
   String buildCommand() {
     var command = 'notify:';
@@ -83,6 +89,14 @@ class NotifyVerbBuilder implements VerbBuilder {
       ccd ??= false;
       command += 'ttr:$ttr:ccd:$ccd:';
     }
+
+    if (sharedKeyEncrypted != null) {
+      command += '$SHARED_KEY_ENCRYPTED:$sharedKeyEncrypted:';
+    }
+    if (pubKeyChecksum != null) {
+      command += '$SHARED_WITH_PUBLIC_KEY_CHECK_SUM:$pubKeyChecksum:';
+    }
+
     if (sharedWith != null) {
       command += '${VerbUtil.formatAtSign(sharedWith)}:';
     }

--- a/at_commons/lib/src/verb/syntax.dart
+++ b/at_commons/lib/src/verb/syntax.dart
@@ -29,7 +29,7 @@ class VerbSyntax {
   static const stream =
       r'^stream:((?<operation>init|send|receive|done|resume))?((@(?<receiver>[^@:\s]+)))?( ?namespace:(?<namespace>[\w-]+))?( ?startByte:(?<startByte>\d+))?( (?<streamId>[\w-]*))?( (?<fileName>.* ))?((?<length>\d*))?$';
   static const notify =
-      r'^notify:((?<operation>update|delete):)?(messageType:(?<messageType>key|text):)?(priority:(?<priority>low|medium|high):)?(strategy:(?<strategy>all|latest):)?(latestN:(?<latestN>\d+):)?(notifier:(?<notifier>[^\s:]+):)?(ttln:(?<ttln>\d+):)?(ttl:(?<ttl>\d+):)?(ttb:(?<ttb>\d+):)?(ttr:(?<ttr>(-)?\d+):)?(ccd:(?<ccd>true|false):)?(@(?<forAtSign>[^@:\s]*)):(?<atKey>[^:@]((?!:{2})[^@])+)(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
+      r'^notify:((?<operation>update|delete):)?(messageType:(?<messageType>key|text):)?(priority:(?<priority>low|medium|high):)?(strategy:(?<strategy>all|latest):)?(latestN:(?<latestN>\d+):)?(notifier:(?<notifier>[^\s:]+):)?(ttln:(?<ttln>\d+):)?(ttl:(?<ttl>\d+):)?(ttb:(?<ttb>\d+):)?(ttr:(?<ttr>(-)?\d+):)?(ccd:(?<ccd>true|false):)?(sharedKeyEnc:(?<sharedKeyEnc>[^:@]+):)?(pubKeyCS:(?<pubKeyCS>[^:@]+))?(@(?<forAtSign>[^@:\s]*)):(?<atKey>[^:@]((?!:{2})[^@])+)(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
   static const notifyList =
       r'^notify:list(:(?<fromDate>\d{4}-[01]?\d?-[0123]?\d?))?(:(?<toDate>\d{4}-[01]?\d?-[0123]?\d?))?(:(?<regex>[^:]+))?';
   static const notifyStatus = r'^notify:status:(?<notificationId>\S+)$';

--- a/at_commons/pubspec.yaml
+++ b/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the @‎platform.
-version: 3.0.7
+version: 3.0.8
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/at_commons/test/notify_verb_builder_test.dart
+++ b/at_commons/test/notify_verb_builder_test.dart
@@ -1,0 +1,39 @@
+import 'package:at_commons/at_builders.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of notify verb builder tests to check notify command', () {
+    test('notify public key', () {
+      var notifyVerbBuilder = NotifyVerbBuilder()
+        ..value = 'alice@gmail.com'
+        ..isPublic = true
+        ..atKey = 'email'
+        ..sharedBy = 'alice';
+      expect(notifyVerbBuilder.buildCommand(),
+          'notify:notifier:SYSTEM:public:email@alice:alice@gmail.com\n');
+    });
+
+    test('notify public key with ttl', () {
+      var notifyVerbBuilder = NotifyVerbBuilder()
+        ..value = 'alice@gmail.com'
+        ..isPublic = true
+        ..atKey = 'email'
+        ..sharedBy = 'alice'
+        ..ttl = 1000;
+      expect(notifyVerbBuilder.buildCommand(),
+          'notify:notifier:SYSTEM:ttl:1000:public:email@alice:alice@gmail.com\n');
+    });
+
+    test('notify shared key command', () {
+      var notifyVerbBuilder = NotifyVerbBuilder()
+        ..value = 'alice@atsign.com'
+        ..atKey = 'email'
+        ..sharedBy = 'alice'
+        ..sharedWith = 'bob'
+        ..pubKeyChecksum = '123'
+        ..sharedKeyEncrypted = 'abc';
+      expect(notifyVerbBuilder.buildCommand(),
+          'notify:notifier:SYSTEM:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**
- Support for encryption shared key and public key in notify verb
**- How I did it**
- modified notify verb builder and notify verb syntax
**- How to verify it**
- run the unit test notify_verb_builder_test.dart
