### PR TITLE
Add id to notify_verb_handler.dart

### DIFF
--- a/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -2,6 +2,9 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/src/verb/verb_builder.dart';
 
 class NotifyVerbBuilder implements VerbBuilder {
+  /// id for each notification.
+  late String id;
+
   /// Key that represents a user's information. e.g phone, location, email etc.,
   String? atKey;
 
@@ -58,7 +61,7 @@ class NotifyVerbBuilder implements VerbBuilder {
 
   @override
   String buildCommand() {
-    var command = 'notify:';
+    var command = 'notify:id:$id:';
 
     if (operation != null) {
       command += '${getOperationName(operation)}:';

--- a/at_commons/test/notify_verb_builder_test.dart
+++ b/at_commons/test/notify_verb_builder_test.dart
@@ -5,27 +5,30 @@ void main() {
   group('A group of notify verb builder tests to check notify command', () {
     test('notify public key', () {
       var notifyVerbBuilder = NotifyVerbBuilder()
+        ..id = '123'
         ..value = 'alice@gmail.com'
         ..isPublic = true
         ..atKey = 'email'
         ..sharedBy = 'alice';
       expect(notifyVerbBuilder.buildCommand(),
-          'notify:notifier:SYSTEM:public:email@alice:alice@gmail.com\n');
+          'notify:id:123:notifier:SYSTEM:public:email@alice:alice@gmail.com\n');
     });
 
     test('notify public key with ttl', () {
       var notifyVerbBuilder = NotifyVerbBuilder()
+        ..id = '123'
         ..value = 'alice@gmail.com'
         ..isPublic = true
         ..atKey = 'email'
         ..sharedBy = 'alice'
         ..ttl = 1000;
       expect(notifyVerbBuilder.buildCommand(),
-          'notify:notifier:SYSTEM:ttl:1000:public:email@alice:alice@gmail.com\n');
+          'notify:id:123:notifier:SYSTEM:ttl:1000:public:email@alice:alice@gmail.com\n');
     });
 
     test('notify shared key command', () {
       var notifyVerbBuilder = NotifyVerbBuilder()
+        ..id = '123'
         ..value = 'alice@atsign.com'
         ..atKey = 'email'
         ..sharedBy = 'alice'
@@ -33,7 +36,7 @@ void main() {
         ..pubKeyChecksum = '123'
         ..sharedKeyEncrypted = 'abc';
       expect(notifyVerbBuilder.buildCommand(),
-          'notify:notifier:SYSTEM:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');
+          'notify:id:123:notifier:SYSTEM:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');
     });
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Changes to have same notification id across sender and receiver.

**- How I did it**

Add `id` in `notify_verb_builder.dart`
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->