### PR TITLE
Added optional parameter to info verb. Valid syntax is now either 'in…

### DIFF
--- a/at_commons/lib/src/verb/syntax.dart
+++ b/at_commons/lib/src/verb/syntax.dart
@@ -36,7 +36,7 @@ class VerbSyntax {
   static const notifyAll =
       r'^notify:all:((?<operation>update|delete):)?(messageType:((?<messageType>key|text):))?(?:ttl:(?<ttl>\d+):)?(?:ttb:(?<ttb>\d+):)?(?:ttr:(?<ttr>-?\d+):)?(?:ccd:(?<ccd>true|false+):)?(?<forAtSign>(([^:\s])+)?(,([^:\s]+))*)(:(?<atKey>[^@:\s]+))(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
   static const batch = r'^batch:(?<json>.+)$';
-  static const info = r'^info$';
+  static const info = r'^info(:brief)?$';
   static const noOp = r'^noop:(?<delayMillis>\d+)$';
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
 }

--- a/at_commons/pubspec.yaml
+++ b/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the @‎platform.
-version: 3.0.11
+version: 3.0.12
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 


### PR DESCRIPTION
**- What I did**
Added optional parameter to info verb. Valid syntax is now either `info` or `info:brief`
Bumped at_commons version from 3.0.11 to 3.0.12

**- How I did it**
In at_tools/at_commons, modified verb/syntax.dart

**- How to verify it**
Eyeball the regex

**- Description for the changelog**
Added optional parameter to info verb. Valid syntax is now either `info` or `info:brief`
