### PR TITLE
Add backward compatibility to notification id.

### DIFF
--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.13
+- Generate default notification id
 ## 3.0.12
 - Added optional parameter to info verb. Valid syntax is now either 'info' or 'info:brief'
 ## 3.0.11

--- a/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -1,9 +1,10 @@
 import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/src/verb/verb_builder.dart';
+import 'package:uuid/uuid.dart';
 
 class NotifyVerbBuilder implements VerbBuilder {
   /// id for each notification.
-  late String id;
+  String id = Uuid().v4();
 
   /// Key that represents a user's information. e.g phone, location, email etc.,
   String? atKey;

--- a/at_commons/pubspec.yaml
+++ b/at_commons/pubspec.yaml
@@ -1,11 +1,14 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the @‎platform.
-version: 3.0.12
+version: 3.0.13
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  uuid: ^3.0.4
 
 dev_dependencies:
   lints: ^1.0.1

--- a/at_commons/test/notify_verb_builder_test.dart
+++ b/at_commons/test/notify_verb_builder_test.dart
@@ -1,5 +1,8 @@
 import 'package:at_commons/at_builders.dart';
+import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
+
+import 'syntax_test.dart';
 
 void main() {
   group('A group of notify verb builder tests to check notify command', () {
@@ -37,6 +40,31 @@ void main() {
         ..sharedKeyEncrypted = 'abc';
       expect(notifyVerbBuilder.buildCommand(),
           'notify:id:123:notifier:SYSTEM:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');
+    });
+  });
+
+  group('A group of tests to verify notification id generation', () {
+    test('Test to verify default notification id is generated', () {
+      var verbHandler = NotifyVerbBuilder()
+        ..atKey = 'phone'
+        ..sharedWith = '@alice'
+        ..sharedBy = '@bob';
+
+      var notifyCommand = verbHandler.buildCommand();
+      var verbParams = getVerbParams(VerbSyntax.notify, notifyCommand.trim());
+      expect(verbParams[ID] != null, true);
+    });
+
+    test('Test to verify custom set notification id to verb builder', () {
+      var verbHandler = NotifyVerbBuilder()
+        ..id = 'abc-123'
+        ..atKey = 'phone'
+        ..sharedWith = '@alice'
+        ..sharedBy = '@bob';
+
+      var notifyCommand = verbHandler.buildCommand();
+      var verbParams = getVerbParams(VerbSyntax.notify, notifyCommand.trim());
+      expect(verbParams[ID], 'abc-123');
     });
   });
 }

--- a/at_commons/test/syntax_test.dart
+++ b/at_commons/test/syntax_test.dart
@@ -8,7 +8,7 @@ void main() {
     test('Test to verify notify verb with encryptedSharedKey and checksum', () {
       var command =
           'notify:update:priority:low:strategy:all:latestN:1:sharedKeyEnc:GxIjM8e/nsga3:pubKeyCS:5d52f6f2868:@bob:phone.wavi@alice:989745456';
-      var verbParams = _getVerbParams(VerbSyntax.notify, command);
+      var verbParams = getVerbParams(VerbSyntax.notify, command);
       expect(verbParams[OPERATION], 'update');
       expect(verbParams[SHARED_KEY_ENCRYPTED], 'GxIjM8e/nsga3');
       expect(verbParams[SHARED_WITH_PUBLIC_KEY_CHECK_SUM], '5d52f6f2868');
@@ -21,7 +21,7 @@ void main() {
     test('Test to verify notify verb with delete operation', () {
       var command =
           'notify:delete:priority:low:strategy:all:latestN:1:sharedKeyEnc:GxIjM8e/nsga3:pubKeyCS:5d52f6f2868:@bob:phone.wavi@alice:989745456';
-      var verbParams = _getVerbParams(VerbSyntax.notify, command);
+      var verbParams = getVerbParams(VerbSyntax.notify, command);
       expect(verbParams[OPERATION], 'delete');
       expect(verbParams[SHARED_KEY_ENCRYPTED], 'GxIjM8e/nsga3');
       expect(verbParams[SHARED_WITH_PUBLIC_KEY_CHECK_SUM], '5d52f6f2868');
@@ -35,19 +35,19 @@ void main() {
   group('A group of tests to verify notify delete verb', () {
     test('Valid id sent to notify delete', () {
       var command = 'notify:remove:abcd-1234';
-      var verbParams = _getVerbParams(VerbSyntax.notifyRemove, command);
+      var verbParams = getVerbParams(VerbSyntax.notifyRemove, command);
       expect(verbParams[ID], 'abcd-1234');
     });
 
     test('id not sent to notify delete', () {
       var command = 'notify:remove:';
-      var verbParams = _getVerbParams(VerbSyntax.notifyRemove, command);
+      var verbParams = getVerbParams(VerbSyntax.notifyRemove, command);
       expect(verbParams.isEmpty, true);
     });
   });
 }
 
-Map _getVerbParams(String regex, String command) {
+Map getVerbParams(String regex, String command) {
   var regExp = RegExp(regex, caseSensitive: false);
   var regexMatches = regExp.allMatches(command);
   var paramsMap = HashMap<String, String?>();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Generate a default notification id to provide a backward compatibility.

**- How I did it**
Set `id` in `NotifyVerbBuilder` class to `Uuid().v4` by default. The default id gets overridden if the user set's id explicitly.

