### PR TITLE
changes for bypassing cache in verb syntax and builders

### DIFF
--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.0.15
-- Support for bypass cache in lookup and plookup verbs
+- FEAT: support to bypass cache in lookup and plookup verbs
 ## 3.0.14
 - Remove unnecessary print statements
 ## 3.0.13

--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.15
+- Support for bypass cache in lookup and plookup verbs
 ## 3.0.14
 - Remove unnecessary print statements
 ## 3.0.13

--- a/at_commons/lib/src/at_constants.dart
+++ b/at_commons/lib/src/at_constants.dart
@@ -63,4 +63,4 @@ const String commitLogCompactionKey = 'privatekey:commitLogCompactionStats';
 const String accessLogCompactionKey = 'privatekey:accessLogCompactionStats';
 const String notificationCompactionKey =
     'privatekey:notificationCompactionStats';
-const String byPassCache = 'bypass_cache';
+const String byPassCache = 'bypassCache';

--- a/at_commons/lib/src/at_constants.dart
+++ b/at_commons/lib/src/at_constants.dart
@@ -63,3 +63,4 @@ const String commitLogCompactionKey = 'privatekey:commitLogCompactionStats';
 const String accessLogCompactionKey = 'privatekey:accessLogCompactionStats';
 const String notificationCompactionKey =
     'privatekey:notificationCompactionStats';
+const String byPassCache = 'bypass_cache';

--- a/at_commons/lib/src/verb/lookup_verb_builder.dart
+++ b/at_commons/lib/src/verb/lookup_verb_builder.dart
@@ -26,15 +26,20 @@ class LookupVerbBuilder implements VerbBuilder {
 
   String? operation;
 
+  // if set to true, returns the value of key on the remote server instead of the cached copy
+  bool byPassCache = false;
+
   @override
   String buildCommand() {
-    String command;
-    if (operation != null) {
-      command = 'lookup:$operation:$atKey${VerbUtil.formatAtSign(sharedBy)}\n';
-    } else {
-      command = 'lookup:$atKey${VerbUtil.formatAtSign(sharedBy)}\n';
+    String command = 'lookup:';
+    if (byPassCache == true) {
+      command += 'bypass_cache:$byPassCache:';
     }
-    return command;
+    if (operation != null) {
+      command += '$operation:';
+    }
+    command += atKey!;
+    return '$command${VerbUtil.formatAtSign(sharedBy)}\n';
   }
 
   @override

--- a/at_commons/lib/src/verb/lookup_verb_builder.dart
+++ b/at_commons/lib/src/verb/lookup_verb_builder.dart
@@ -33,7 +33,7 @@ class LookupVerbBuilder implements VerbBuilder {
   String buildCommand() {
     String command = 'lookup:';
     if (byPassCache == true) {
-      command += 'bypass_cache:$byPassCache:';
+      command += 'bypassCache:$byPassCache:';
     }
     if (operation != null) {
       command += '$operation:';

--- a/at_commons/lib/src/verb/plookup_verb_builder.dart
+++ b/at_commons/lib/src/verb/plookup_verb_builder.dart
@@ -17,15 +17,20 @@ class PLookupVerbBuilder implements VerbBuilder {
 
   String? operation;
 
+  // if set to true, returns the value of key on the remote server instead of the cached copy
+  bool byPassCache = false;
+
   @override
   String buildCommand() {
-    String command;
-    if (operation != null) {
-      command = 'plookup:$operation:$atKey${VerbUtil.formatAtSign(sharedBy)}\n';
-    } else {
-      command = 'plookup:$atKey${VerbUtil.formatAtSign(sharedBy)}\n';
+    String command = 'plookup:';
+    if (byPassCache == true) {
+      command += 'bypass_cache:$byPassCache:';
     }
-    return command;
+    if (operation != null) {
+      command += '$operation:';
+    }
+    command += atKey!;
+    return '$command${VerbUtil.formatAtSign(sharedBy)}\n';
   }
 
   @override

--- a/at_commons/lib/src/verb/plookup_verb_builder.dart
+++ b/at_commons/lib/src/verb/plookup_verb_builder.dart
@@ -24,7 +24,7 @@ class PLookupVerbBuilder implements VerbBuilder {
   String buildCommand() {
     String command = 'plookup:';
     if (byPassCache == true) {
-      command += 'bypass_cache:$byPassCache:';
+      command += 'bypassCache:$byPassCache:';
     }
     if (operation != null) {
       command += '$operation:';

--- a/at_commons/lib/src/verb/syntax.dart
+++ b/at_commons/lib/src/verb/syntax.dart
@@ -6,9 +6,9 @@ class VerbSyntax {
   static const llookup =
       r'^llookup:((?<operation>meta|all):)?(?:cached:)?((?:public:)|(@(?<forAtSign>[^@:\s]*):))?(?<atKey>[^:]((?!:{2})[^@])+)@(?<atSign>[^@\s]+)$';
   static const plookup =
-      r'^plookup:(bypass_cache:(?<bypass_cache>true|false):)?((?<operation>meta|all):)?(?<atKey>[^@\s]+)@(?<atSign>[^@\s]+)$';
+      r'^plookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>[^@\s]+)@(?<atSign>[^@\s]+)$';
   static const lookup =
-      r'^lookup:(bypass_cache:(?<bypass_cache>true|false):)?((?<operation>meta|all):)?(?<atKey>(?:[^:]).+)@(?<atSign>[^@\s]+)$';
+      r'^lookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>(?:[^:]).+)@(?<atSign>[^@\s]+)$';
   static const scan =
       r'^scan$|scan(:(?<forAtSign>@[^:@\s]+))?(:page:(?<page>\d+))?( (?<regex>\S+))?$';
   static const config =

--- a/at_commons/lib/src/verb/syntax.dart
+++ b/at_commons/lib/src/verb/syntax.dart
@@ -6,9 +6,9 @@ class VerbSyntax {
   static const llookup =
       r'^llookup:((?<operation>meta|all):)?(?:cached:)?((?:public:)|(@(?<forAtSign>[^@:\s]*):))?(?<atKey>[^:]((?!:{2})[^@])+)@(?<atSign>[^@\s]+)$';
   static const plookup =
-      r'^plookup:((?<operation>meta|all):)?(?<atKey>[^@\s]+)@(?<atSign>[^@\s]+)$';
+      r'^plookup:(bypass_cache:(?<bypass_cache>true|false):)?((?<operation>meta|all):)?(?<atKey>[^@\s]+)@(?<atSign>[^@\s]+)$';
   static const lookup =
-      r'^lookup:((?<operation>meta|all):)?(?<atKey>(?:[^:]).+)@(?<atSign>[^@\s]+)$';
+      r'^lookup:(bypass_cache:(?<bypass_cache>true|false):)?((?<operation>meta|all):)?(?<atKey>(?:[^:]).+)@(?<atSign>[^@\s]+)$';
   static const scan =
       r'^scan$|scan(:(?<forAtSign>@[^:@\s]+))?(:page:(?<page>\d+))?( (?<regex>\S+))?$';
   static const config =

--- a/at_commons/pubspec.yaml
+++ b/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the @‎platform.
-version: 3.0.14
+version: 3.0.15
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/at_commons/test/lookup_verb_builder_test.dart
+++ b/at_commons/test/lookup_verb_builder_test.dart
@@ -1,0 +1,37 @@
+import 'package:at_commons/at_builders.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of lookup verb builder tests', () {
+    test('verify simple lookup command', () {
+      var updateBuilder = LookupVerbBuilder()
+        ..atKey = 'phone'
+        ..sharedBy = 'alice';
+      expect(updateBuilder.buildCommand(), 'lookup:phone@alice\n');
+    });
+    test('verify lookup meta command', () {
+      var updateBuilder = LookupVerbBuilder()
+        ..operation = 'meta'
+        ..atKey = 'email'
+        ..sharedBy = 'alice';
+      expect(updateBuilder.buildCommand(), 'lookup:meta:email@alice\n');
+    });
+
+    test('verify lookup all command', () {
+      var updateBuilder = LookupVerbBuilder()
+        ..operation = 'all'
+        ..atKey = 'email'
+        ..sharedBy = 'alice';
+      expect(updateBuilder.buildCommand(), 'lookup:all:email@alice\n');
+    });
+
+    test('verify lookup bypass cache command', () {
+      var updateBuilder = LookupVerbBuilder()
+        ..byPassCache = true
+        ..atKey = 'email'
+        ..sharedBy = 'alice';
+      expect(updateBuilder.buildCommand(),
+          'lookup:bypass_cache:true:email@alice\n');
+    });
+  });
+}

--- a/at_commons/test/lookup_verb_builder_test.dart
+++ b/at_commons/test/lookup_verb_builder_test.dart
@@ -31,7 +31,7 @@ void main() {
         ..atKey = 'email'
         ..sharedBy = 'alice';
       expect(updateBuilder.buildCommand(),
-          'lookup:bypass_cache:true:email@alice\n');
+          'lookup:bypassCache:true:email@alice\n');
     });
   });
 }

--- a/at_commons/test/lookup_verb_builder_test.dart
+++ b/at_commons/test/lookup_verb_builder_test.dart
@@ -4,33 +4,33 @@ import 'package:test/test.dart';
 void main() {
   group('A group of lookup verb builder tests', () {
     test('verify simple lookup command', () {
-      var updateBuilder = LookupVerbBuilder()
+      var lookupVerbBuilder = LookupVerbBuilder()
         ..atKey = 'phone'
         ..sharedBy = 'alice';
-      expect(updateBuilder.buildCommand(), 'lookup:phone@alice\n');
+      expect(lookupVerbBuilder.buildCommand(), 'lookup:phone@alice\n');
     });
     test('verify lookup meta command', () {
-      var updateBuilder = LookupVerbBuilder()
+      var lookupVerbBuilder = LookupVerbBuilder()
         ..operation = 'meta'
         ..atKey = 'email'
         ..sharedBy = 'alice';
-      expect(updateBuilder.buildCommand(), 'lookup:meta:email@alice\n');
+      expect(lookupVerbBuilder.buildCommand(), 'lookup:meta:email@alice\n');
     });
 
     test('verify lookup all command', () {
-      var updateBuilder = LookupVerbBuilder()
+      var lookupVerbBuilder = LookupVerbBuilder()
         ..operation = 'all'
         ..atKey = 'email'
         ..sharedBy = 'alice';
-      expect(updateBuilder.buildCommand(), 'lookup:all:email@alice\n');
+      expect(lookupVerbBuilder.buildCommand(), 'lookup:all:email@alice\n');
     });
 
     test('verify lookup bypass cache command', () {
-      var updateBuilder = LookupVerbBuilder()
+      var lookupVerbBuilder = LookupVerbBuilder()
         ..byPassCache = true
         ..atKey = 'email'
         ..sharedBy = 'alice';
-      expect(updateBuilder.buildCommand(),
+      expect(lookupVerbBuilder.buildCommand(),
           'lookup:bypassCache:true:email@alice\n');
     });
   });

--- a/at_commons/test/plookup_verb_builder_test.dart
+++ b/at_commons/test/plookup_verb_builder_test.dart
@@ -1,0 +1,37 @@
+import 'package:at_commons/at_builders.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of lookup verb builder tests', () {
+    test('verify simple plookup command', () {
+      var updateBuilder = PLookupVerbBuilder()
+        ..atKey = 'phone'
+        ..sharedBy = 'alice';
+      expect(updateBuilder.buildCommand(), 'plookup:phone@alice\n');
+    });
+    test('verify plookup meta command', () {
+      var updateBuilder = PLookupVerbBuilder()
+        ..operation = 'meta'
+        ..atKey = 'email'
+        ..sharedBy = 'alice';
+      expect(updateBuilder.buildCommand(), 'plookup:meta:email@alice\n');
+    });
+
+    test('verify plookup all command', () {
+      var updateBuilder = PLookupVerbBuilder()
+        ..operation = 'all'
+        ..atKey = 'email'
+        ..sharedBy = 'alice';
+      expect(updateBuilder.buildCommand(), 'plookup:all:email@alice\n');
+    });
+
+    test('verify plookup bypass cache command', () {
+      var updateBuilder = PLookupVerbBuilder()
+        ..byPassCache = true
+        ..atKey = 'email'
+        ..sharedBy = 'alice';
+      expect(updateBuilder.buildCommand(),
+          'plookup:bypass_cache:true:email@alice\n');
+    });
+  });
+}

--- a/at_commons/test/plookup_verb_builder_test.dart
+++ b/at_commons/test/plookup_verb_builder_test.dart
@@ -4,33 +4,33 @@ import 'package:test/test.dart';
 void main() {
   group('A group of lookup verb builder tests', () {
     test('verify simple plookup command', () {
-      var updateBuilder = PLookupVerbBuilder()
+      var plookupVerbBuilder = PLookupVerbBuilder()
         ..atKey = 'phone'
         ..sharedBy = 'alice';
-      expect(updateBuilder.buildCommand(), 'plookup:phone@alice\n');
+      expect(plookupVerbBuilder.buildCommand(), 'plookup:phone@alice\n');
     });
     test('verify plookup meta command', () {
-      var updateBuilder = PLookupVerbBuilder()
+      var plookupVerbBuilder = PLookupVerbBuilder()
         ..operation = 'meta'
         ..atKey = 'email'
         ..sharedBy = 'alice';
-      expect(updateBuilder.buildCommand(), 'plookup:meta:email@alice\n');
+      expect(plookupVerbBuilder.buildCommand(), 'plookup:meta:email@alice\n');
     });
 
     test('verify plookup all command', () {
-      var updateBuilder = PLookupVerbBuilder()
+      var plookupVerbBuilder = PLookupVerbBuilder()
         ..operation = 'all'
         ..atKey = 'email'
         ..sharedBy = 'alice';
-      expect(updateBuilder.buildCommand(), 'plookup:all:email@alice\n');
+      expect(plookupVerbBuilder.buildCommand(), 'plookup:all:email@alice\n');
     });
 
     test('verify plookup bypass cache command', () {
-      var updateBuilder = PLookupVerbBuilder()
+      var plookupVerbBuilder = PLookupVerbBuilder()
         ..byPassCache = true
         ..atKey = 'email'
         ..sharedBy = 'alice';
-      expect(updateBuilder.buildCommand(),
+      expect(plookupVerbBuilder.buildCommand(),
           'plookup:bypassCache:true:email@alice\n');
     });
   });

--- a/at_commons/test/plookup_verb_builder_test.dart
+++ b/at_commons/test/plookup_verb_builder_test.dart
@@ -31,7 +31,7 @@ void main() {
         ..atKey = 'email'
         ..sharedBy = 'alice';
       expect(updateBuilder.buildCommand(),
-          'plookup:bypass_cache:true:email@alice\n');
+          'plookup:bypassCache:true:email@alice\n');
     });
   });
 }


### PR DESCRIPTION
**- What I did**
- added support for bypassing cache for plookup and lookup verbs
**- How I did it**
- modified verb syntax of plookup and lookup verb in syntax.dart
- added bypass cache and refactored buildCommand of plookup and lookup verb builders
- added unit tests

**- How to verify it**
- run the unit tests plookup_verb_builder_test and lookup_verb_builder_test
