### PR TITLE
hide at_client_exceptions.dart file

### DIFF
--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.16
+- Hide at_client_exceptions.dart to prevent at_client_exception being referred from at_commons
 ## 3.0.15
 - FEAT: support to bypass cache in lookup and plookup verbs
 ## 3.0.14

--- a/at_commons/lib/at_commons.dart
+++ b/at_commons/lib/at_commons.dart
@@ -5,7 +5,6 @@ export 'package:at_commons/src/at_message.dart';
 export 'package:at_commons/src/buffer/at_buffer.dart';
 export 'package:at_commons/src/buffer/at_buffer_impl.dart';
 export 'package:at_commons/src/compaction/at_compaction_config.dart';
-export 'package:at_commons/src/exception/at_client_exceptions.dart';
 export 'package:at_commons/src/exception/at_exception_utils.dart';
 export 'package:at_commons/src/exception/at_exceptions.dart'
     hide

--- a/at_commons/pubspec.yaml
+++ b/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the @‎platform.
-version: 3.0.15
+version: 3.0.16
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Hide at_client_exceptions.dart to prevent `AtClientException` being referred from at_commons package.

**- How I did it**
Remove the export line at_commons.dart file

**- How to verify it**
The `AtClientException` should be referred only from at_client package.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->