### PR TITLE
at_cram_single (digest in one command)

### DIFF
--- a/at_cram/README.md
+++ b/at_cram/README.md
@@ -26,6 +26,16 @@ For example when using VE
 
 [![asciicast](https://asciinema.org/a/4YBCRUt4duFs9u4fAEfmMhhAS.svg)](https://asciinema.org/a/4YBCRUt4duFs9u4fAEfmMhhAS)
 
+### at_cram_single
+The `at_cram_single` dart program can cram digest all in a single command. Simply:
+1. `dart bin/at_cram_single.dart <cramSecret> <challenge>`
+2. Program will output digest (Use the digest via `cram:<digest>` in the @protocol)
+
+Or compile the program:
+1. Compile `dart compile exe bin/at_cram_single.dart -o cram`
+2. Run `./cram <cramSecret> <digest>`
+3. Program will output digest (Use the digest via `cram:<digest>` in the @protocol)
+
 Here we connect to the @colin🛠  secondary on port 25004 using openssl and then issue the from: verb with
 @colin🛠 as the argument, the challenge is given back in return. This challenge is then put into the
 at_cram tool and a digest given back. This digest in then entered using the cram: verb and it is successful 

--- a/at_cram/bin/at_cram_single.dart
+++ b/at_cram/bin/at_cram_single.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:args/args.dart';
 import 'package:crypto/crypto.dart';
 
 /// command-line usage

--- a/at_cram/bin/at_cram_single.dart
+++ b/at_cram/bin/at_cram_single.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:crypto/crypto.dart';
+
+// command-line usage
+
+// (1)
+// first compile this file (replace <name> with the name of the file)
+// dart compile exe bin/at_cram_single.dart -o <name>
+
+// (2)
+// run the compiled file
+// ./cram <cramSecret> <from: challenge>
+
+// (3)
+// program spits out digest
+// in openssl, you can now do `cram:<digest>`
+
+void main(List<String> arguments) {
+  if (arguments.length != 2) {
+    print('Invalid usage! CRAM <cramSecret> <from challenge>');
+    return;
+  }
+  var cramSecret = arguments[0];
+  var challenge = arguments[1];
+  cramSecret = cramSecret.trim();
+  challenge = challenge.trim();
+  var combo = '$cramSecret$challenge';
+  var bytes = utf8.encode(combo);
+  var digest = sha512.convert(bytes);
+  stdout.write('\n');
+  stdout.write(digest);
+  stdout.write('\n');
+}

--- a/at_cram/bin/at_cram_single.dart
+++ b/at_cram/bin/at_cram_single.dart
@@ -18,18 +18,32 @@ import 'package:crypto/crypto.dart';
 /// in openssl, you can now do `cram:<digest>`
 
 void main(List<String> arguments) {
-  if (arguments.length != 2) {
-    print('Invalid usage! CRAM <cramSecret> <from challenge>');
+  if (arguments.length != 4) {
+    _printInstructions();
     return;
   }
-  var cramSecret = arguments[0];
-  var challenge = arguments[1];
+  var parser = ArgParser();
+  parser.addOption('cramSecret', abbr: 'k', mandatory: true, help: 'CRAM secret initially retrieved upon receiving an atSign.');
+  parser.addOption('challenge',
+      abbr: 'c', mandatory: true, help: 'The challenge received after doing `from:@myatsign`, you get: `data:<challenge>` where <challenge> is the challenge.');
+  var results = parser.parse(arguments);
+  var cramSecret = results['cramSecret'];
+  var challenge = results['challenge'];
   cramSecret = cramSecret.trim();
   challenge = challenge.trim();
+  stdout.write('\ncramSecret: $cramSecret\n');
+  stdout.write('challenge: $challenge\n');
   var combo = '$cramSecret$challenge';
   var bytes = utf8.encode(combo);
   var digest = sha512.convert(bytes);
   stdout.write('\n');
-  stdout.write(digest);
+  stdout.write('digest: $digest');
   stdout.write('\n');
+}
+
+void _printInstructions() {
+  stdout.write('\nCRAM digesting in one single line\n');
+  stdout.write('  --cramSecret -k \t| cramSecret received when you initially get an @ sign (usually in the form of a QR code)\n');
+  stdout.write('  --challenge -c \t| the challenge response you receive after doing `from:@youratsign`, will respond with `data:<challenge>`\n');
+  stdout.write('  Example: `dart bin/at_cram_single.dart -k cramSecret123 -c fromChallenge123`\n');
 }

--- a/at_cram/bin/at_cram_single.dart
+++ b/at_cram/bin/at_cram_single.dart
@@ -2,19 +2,19 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:crypto/crypto.dart';
 
-// command-line usage
+/// command-line usage
 
-// (1)
-// first compile this file (replace <name> with the name of the file)
-// dart compile exe bin/at_cram_single.dart -o <name>
+/// (1)
+/// first compile this file (replace <name> with the name of the file)
+/// dart compile exe bin/at_cram_single.dart -o <name>
 
-// (2)
-// run the compiled file
-// ./cram <cramSecret> <from: challenge>
+/// (2)
+/// run the compiled file, <cramSecret> comes from initial retrieval of your atSign (in your QR code or web API), <challenge> comes from the `from:@sign` challenge.
+/// ./cram -k <cramSecret> -c <challenge>
 
-// (3)
-// program spits out digest
-// in openssl, you can now do `cram:<digest>`
+/// (3)
+/// program spits out digest
+/// in openssl, you can now do `cram:<digest>`
 
 void main(List<String> arguments) {
   if (arguments.length != 2) {

--- a/at_cram/pubspec.yaml
+++ b/at_cram/pubspec.yaml
@@ -11,3 +11,6 @@ environment:
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.5
+
+dependencies:
+  args: ^2.3.1


### PR DESCRIPTION
**- What I did**
- Create `at_cram_single.dart` to work with manual input for cram digesting
- Add `at_cram_single` documentation to `at_cram/README.md`
- Usage: `dart bin/at_cram_single.dart <cramSecret> <challenge>`

**- How I did it**
See `at_cram_single.dart`

**- How to verify it**
```
madiv@Jeremy-PC MINGW64 ~
$ openssl s_client -ign_eof -brief 06458a2c-8fda-50e6-b875-44e9db94db87.stagin001.atsign.zone:3920
@scan
data:["signing_publickey@comparativethe74"]
@from:@comparativethe74
data:_a4d3c1e4-7c90-4cc3-8e3e-078ec8eea3fa@comparativethe74:894cfa9b-94c1-46c2-9fc6-c527700151d4
@cram:a7d41fb832d623033bf6907b72b3476283d382ceb6acc4a3d5c2c3139c86b949a709062b73c63f40d00cf9a52b32dfe31b36400798d8b6b2645287ca2999a999
data:success
@comparativethe74@scan
data:["@comparativethe74:signing_privatekey@comparativethe74","public:signing_publickey@comparativethe74"]
@comparativethe74@
```

```
./cram_single c5544195f973eb40375f7f4b504ec631c35a8c7ec90e0a353242010880afac5bb6a9566be8d0f5947da697b5f01f651e92297622e49cf06844afb14d7c8e7a5d _a4d3c1e4-7c90-4cc3-8e3e-078ec8eea3fa@comparativethe74:894cfa9b-94c1-46c2-9fc6-c527700151d4

a7d41fb832d623033bf6907b72b3476283d382ceb6acc4a3d5c2c3139c86b949a709062b73c63f40d00cf9a52b32dfe31b36400798d8b6b2645287ca2999a999
```

**- Description for the changelog**