### PR TITLE
fix: remove setting isCached to true from SharedKeyBuilder

### DIFF
--- a/at_commons/lib/src/keystore/at_key_builder_impl.dart
+++ b/at_commons/lib/src/keystore/at_key_builder_impl.dart
@@ -96,7 +96,6 @@ class SharedKeyBuilder extends CachedKeyBuilder {
   void cache(int ttr, bool ccd) {
     _meta.ttr = ttr;
     _meta.ccd = ccd;
-    _meta.isCached = (ttr != 0);
   }
 
   /// Accepts a string which represents an atSign for the key is created.

--- a/at_commons/test/at_key_test.dart
+++ b/at_commons/test/at_key_test.dart
@@ -204,7 +204,6 @@ void main() {
       expect(atKey.metadata!.ttb, equals(null));
       expect(atKey.metadata!.isPublic, equals(false));
       expect(atKey.metadata!.isBinary, equals(false));
-      expect(atKey.metadata!.isCached, equals(true));
     });
   });
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Remove setting `isCached` to true in SharedKeyBuilder. The intent of isCached field is to indicate a key is a cached key (when set to true). 

In this case it was set on the shared key which needs to be cached (setting ttr and ccd). 

**- How I did it**
Remove the line that sets isCached to true.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->