### PR TITLE
feat: Add isTextMessageEncrypted to notify_verb_builder.dart

### DIFF
--- a/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -97,7 +97,7 @@ class NotifyVerbBuilder implements VerbBuilder {
       ccd ??= false;
       command += 'ttr:$ttr:ccd:$ccd:';
     }
-    if(isTextMessageEncrypted){
+    if (isTextMessageEncrypted) {
       command += '$IS_ENCRYPTED:$isTextMessageEncrypted:';
     }
 

--- a/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -54,6 +54,10 @@ class NotifyVerbBuilder implements VerbBuilder {
 
   bool? ccd;
 
+  /// Represents if the [MessageTypeEnum.text] is encrypted or not. Setting to false to preserve
+  /// backward compatibility.
+  bool isTextMessageEncrypted = false;
+
   /// Will be set only when [sharedWith] is set. Will be encrypted using the public key of [sharedWith] atsign
   String? sharedKeyEncrypted;
 
@@ -92,6 +96,9 @@ class NotifyVerbBuilder implements VerbBuilder {
     if (ttr != null) {
       ccd ??= false;
       command += 'ttr:$ttr:ccd:$ccd:';
+    }
+    if(isTextMessageEncrypted){
+      command += '$IS_ENCRYPTED:$isTextMessageEncrypted:';
     }
 
     if (sharedKeyEncrypted != null) {

--- a/at_commons/lib/src/verb/syntax.dart
+++ b/at_commons/lib/src/verb/syntax.dart
@@ -29,7 +29,7 @@ class VerbSyntax {
   static const stream =
       r'^stream:((?<operation>init|send|receive|done|resume))?((@(?<receiver>[^@:\s]+)))?( ?namespace:(?<namespace>[\w-]+))?( ?startByte:(?<startByte>\d+))?( (?<streamId>[\w-]*))?( (?<fileName>.* ))?((?<length>\d*))?$';
   static const notify =
-      r'^notify:(id:(?<id>[\w\d\-\_]+):)?((?<operation>update|delete):)?(messageType:(?<messageType>key|text):)?(priority:(?<priority>low|medium|high):)?(strategy:(?<strategy>all|latest):)?(latestN:(?<latestN>\d+):)?(notifier:(?<notifier>[^\s:]+):)?(ttln:(?<ttln>\d+):)?(ttl:(?<ttl>\d+):)?(ttb:(?<ttb>\d+):)?(ttr:(?<ttr>(-)?\d+):)?(ccd:(?<ccd>true|false):)?(sharedKeyEnc:(?<sharedKeyEnc>[^:@]+):)?(pubKeyCS:(?<pubKeyCS>[^:@]+):)?(@(?<forAtSign>[^@:\s]*)):(?<atKey>[^:@]((?!:{2})[^@])+)(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
+      r'^notify:(id:(?<id>[\w\d\-\_]+):)?((?<operation>update|delete):)?(messageType:(?<messageType>key|text):)?(priority:(?<priority>low|medium|high):)?(strategy:(?<strategy>all|latest):)?(latestN:(?<latestN>\d+):)?(notifier:(?<notifier>[^\s:]+):)?(ttln:(?<ttln>\d+):)?(ttl:(?<ttl>\d+):)?(ttb:(?<ttb>\d+):)?(ttr:(?<ttr>(-)?\d+):)?(ccd:(?<ccd>true|false):)?(isEncrypted:(?<isEncrypted>true|false):)?(sharedKeyEnc:(?<sharedKeyEnc>[^:@]+):)?(pubKeyCS:(?<pubKeyCS>[^:@]+):)?(@(?<forAtSign>[^@:\s]*)):(?<atKey>[^:@]((?!:{2})[^@])+)(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
   static const notifyList =
       r'^notify:list(:(?<fromDate>\d{4}-[01]?\d?-[0123]?\d?))?(:(?<toDate>\d{4}-[01]?\d?-[0123]?\d?))?(:(?<regex>[^:]+))?';
   static const notifyStatus = r'^notify:status:(?<notificationId>\S+)$';

--- a/at_commons/test/notify_verb_builder_test.dart
+++ b/at_commons/test/notify_verb_builder_test.dart
@@ -41,30 +41,68 @@ void main() {
       expect(notifyVerbBuilder.buildCommand(),
           'notify:id:123:notifier:SYSTEM:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');
     });
-  });
 
-  group('A group of tests to verify notification id generation', () {
-    test('Test to verify default notification id is generated', () {
-      var verbHandler = NotifyVerbBuilder()
-        ..atKey = 'phone'
-        ..sharedWith = '@alice'
-        ..sharedBy = '@bob';
-
-      var notifyCommand = verbHandler.buildCommand();
-      var verbParams = getVerbParams(VerbSyntax.notify, notifyCommand.trim());
-      expect(verbParams[ID] != null, true);
-    });
-
-    test('Test to verify custom set notification id to verb builder', () {
-      var verbHandler = NotifyVerbBuilder()
-        ..id = 'abc-123'
-        ..atKey = 'phone'
-        ..sharedWith = '@alice'
-        ..sharedBy = '@bob';
-
-      var notifyCommand = verbHandler.buildCommand();
-      var verbParams = getVerbParams(VerbSyntax.notify, notifyCommand.trim());
-      expect(verbParams[ID], 'abc-123');
+    test('notify text message with isEncrypted set to true', () {
+      var notifyVerbBuilder = NotifyVerbBuilder()
+        ..id = '123'
+        ..value = 'alice@atsign.com'
+        ..atKey = 'email'
+        ..sharedBy = 'alice'
+        ..sharedWith = 'bob'
+        ..pubKeyChecksum = '123'
+        ..sharedKeyEncrypted = 'abc'
+        ..isTextMessageEncrypted = true;
+      expect(notifyVerbBuilder.buildCommand(),
+          'notify:id:123:notifier:SYSTEM:isEncrypted:true:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');
     });
   });
+
+  try {
+    group('A group of tests to verify notification id generation', () {
+      // The below test validates the following:
+      //  1. custom notification id overrides default notification id
+      //  2. IsEncrypted flag when set true is added to verb params.
+      test('Test to verify all notify fields in the verb builder', () {
+        var verbHandler = NotifyVerbBuilder()
+          ..id = 'abc-123'
+          ..atKey = 'phone'
+          ..sharedWith = '@alice'
+          ..sharedBy = '@bob'
+          ..isTextMessageEncrypted = true;
+
+        var notifyCommand = verbHandler.buildCommand();
+        var verbParams = getVerbParams(VerbSyntax.notify, notifyCommand.trim());
+        expect(verbParams[ID], 'abc-123');
+        expect(verbParams[IS_ENCRYPTED], 'true');
+      });
+
+      // The below test validates the following:
+      //  1. Default notification id is generated
+      //  2. IsEncrypted flag is not set by default.
+      test('Test to verify default notification id is generated', () {
+        var verbHandler = NotifyVerbBuilder()
+          ..atKey = 'phone'
+          ..sharedWith = '@alice'
+          ..sharedBy = '@bob';
+
+        var notifyCommand = verbHandler.buildCommand();
+        var verbParams = getVerbParams(VerbSyntax.notify, notifyCommand.trim());
+        expect(verbParams[ID] != null, true);
+        expect(verbParams[IS_ENCRYPTED], null);
+      });
+      test('Test to verify custom set notification id to verb builder', () {
+        var verbHandler = NotifyVerbBuilder()
+          ..id = 'abc-123'
+          ..atKey = 'phone'
+          ..sharedWith = '@alice'
+          ..sharedBy = '@bob';
+
+        var notifyCommand = verbHandler.buildCommand();
+        var verbParams = getVerbParams(VerbSyntax.notify, notifyCommand.trim());
+        expect(verbParams[ID], 'abc-123');
+      });
+    });
+  } catch (e, s) {
+    print(s);
+  }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Add isTextMessageEncrypted to notify verb builder to support encrypting the notification text message.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->