### PR TITLE
fix: bug fixes to AtKey.fromString static method and various toString instance methods

### DIFF
--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -9,6 +9,13 @@ class AtKey {
   Metadata? metadata;
   bool isRef = false;
 
+  String _dotNamespaceIfPresent() {
+    if (namespace != null) {
+      return '.$namespace';
+    } else {
+      return '';
+    }
+  }
   @override
   String toString() {
     // If metadata.isPublic is true and metadata.isCached is true,
@@ -17,19 +24,19 @@ class AtKey {
         (metadata != null &&
             (metadata!.isPublic != null && metadata!.isPublic!) &&
             (metadata!.isCached))) {
-      return 'cached:public:$key.$namespace$sharedBy';
+      return 'cached:public:$key${_dotNamespaceIfPresent()}$sharedBy';
     }
     // If metadata.isPublic is true, return public key
     if (key!.startsWith('public:') ||
         (metadata != null &&
             metadata!.isPublic != null &&
             metadata!.isPublic!)) {
-      return 'public:$key.$namespace$sharedBy';
+      return 'public:$key${_dotNamespaceIfPresent()}$sharedBy';
     }
     //If metadata.isCached is true, return shared cached key
     if (key!.startsWith('cached:') ||
         (metadata != null && metadata!.isCached)) {
-      return 'cached:$sharedWith:$key.$namespace$sharedBy';
+      return 'cached:$sharedWith:$key${_dotNamespaceIfPresent()}$sharedBy';
     }
     // If key starts with privatekey:, return private key
     if (key!.startsWith('privatekey:')) {
@@ -37,10 +44,10 @@ class AtKey {
     }
     //If sharedWith is not null, return sharedKey
     if (sharedWith != null && sharedWith!.isNotEmpty) {
-      return '$sharedWith:$key.$namespace$sharedBy';
+      return '$sharedWith:$key${_dotNamespaceIfPresent()}$sharedBy';
     }
     // Defaults to return a self key.
-    return '$key.$namespace$sharedBy';
+    return '$key${_dotNamespaceIfPresent()}$sharedBy';
   }
 
   /// Public keys are visible to everyone and shown in an authenticated/unauthenticated scan
@@ -129,7 +136,7 @@ class AtKey {
       return atKey;
     } else if (key.startsWith(AT_ENCRYPTION_PRIVATE_KEY)) {
       atKey.key = key.split('@')[0];
-      atKey.sharedBy = key.split('@')[1];
+      atKey.sharedBy = '@${key.split('@')[1]}';
       atKey.metadata = metaData;
       return atKey;
     }
@@ -141,7 +148,7 @@ class AtKey {
     // If key does not contain ':' Ex: phone@bob; then keyParts length is 1
     // where phone is key and @bob is sharedBy
     if (keyParts.length == 1) {
-      atKey.sharedBy = keyParts[0].split('@')[1];
+      atKey.sharedBy = '@${keyParts[0].split('@')[1]}';
       atKey.key = keyParts[0].split('@')[0];
     } else {
       // Example key: public:phone@bob
@@ -155,14 +162,15 @@ class AtKey {
       } else {
         atKey.sharedWith = keyParts[0];
       }
+
       List<String> keyArr = [];
-      if (keyParts[0] == CACHED) {
-        keyArr = keyParts[2].split('@');
-      } else {
-        keyArr = keyParts[1].split('@');
+      if (keyParts[0] == CACHED) { //cached:@alice:phone@bob
+        keyArr = keyParts[2].split('@'); //phone@bob ==> 'phone', 'bob'
+      } else { // @alice:phone@bob
+        keyArr = keyParts[1].split('@'); // phone@bob ==> 'phone', 'bob'
       }
       if (keyArr.length == 2) {
-        atKey.sharedBy = keyArr[1];
+        atKey.sharedBy = '@${keyArr[1]}'; // keyArr[1] is 'bob' so sharedBy needs to be @bob
         atKey.key = keyArr[0];
       } else {
         atKey.key = keyArr[0];
@@ -192,7 +200,7 @@ class PublicKey extends AtKey {
 
   @override
   String toString() {
-    return 'public:$key.$namespace$sharedBy';
+    return 'public:$key${_dotNamespaceIfPresent()}$sharedBy';
   }
 }
 
@@ -209,9 +217,9 @@ class SelfKey extends AtKey {
     // keys is a self key.
     // @alice:phone@alice or phone@alice
     if (sharedWith != null && sharedWith!.isNotEmpty) {
-      return '$sharedWith:$key.$namespace$sharedBy';
+      return '$sharedWith:$key${_dotNamespaceIfPresent()}$sharedBy';
     }
-    return '$key.$namespace$sharedBy';
+    return '$key${_dotNamespaceIfPresent()}$sharedBy';
   }
 }
 
@@ -223,7 +231,7 @@ class SharedKey extends AtKey {
 
   @override
   String toString() {
-    return '$sharedWith:$key.$namespace$sharedBy';
+    return '$sharedWith:$key${_dotNamespaceIfPresent()}$sharedBy';
   }
 }
 

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -3,11 +3,24 @@ import 'package:at_commons/src/keystore/at_key_builder_impl.dart';
 
 class AtKey {
   String? key;
-  String? sharedWith;
-  String? sharedBy;
+  String? _sharedWith;
+  String? _sharedBy;
   String? namespace;
   Metadata? metadata;
   bool isRef = false;
+
+
+  String? get sharedBy => _sharedBy;
+  set sharedBy(String? atSign) {
+    assertStartsWithAtIfNotEmpty(atSign);
+    _sharedBy = atSign;
+  }
+
+  String? get sharedWith => _sharedWith;
+  set sharedWith(String? atSign) {
+    assertStartsWithAtIfNotEmpty(atSign);
+    _sharedWith = atSign;
+  }
 
   String _dotNamespaceIfPresent() {
     if (namespace != null) {
@@ -24,32 +37,37 @@ class AtKey {
         (metadata != null &&
             (metadata!.isPublic != null && metadata!.isPublic!) &&
             (metadata!.isCached))) {
-      return 'cached:public:$key${_dotNamespaceIfPresent()}$sharedBy';
+      return 'cached:public:$key${_dotNamespaceIfPresent()}$_sharedBy';
     }
     // If metadata.isPublic is true, return public key
     if (key!.startsWith('public:') ||
         (metadata != null &&
             metadata!.isPublic != null &&
             metadata!.isPublic!)) {
-      return 'public:$key${_dotNamespaceIfPresent()}$sharedBy';
+      return 'public:$key${_dotNamespaceIfPresent()}$_sharedBy';
     }
     //If metadata.isCached is true, return shared cached key
     if (key!.startsWith('cached:') ||
         (metadata != null && metadata!.isCached)) {
-      return 'cached:$sharedWith:$key${_dotNamespaceIfPresent()}$sharedBy';
+      return 'cached:$_sharedWith:$key${_dotNamespaceIfPresent()}$_sharedBy';
     }
     // If key starts with privatekey:, return private key
     if (key!.startsWith('privatekey:')) {
       return '$key';
     }
-    //If sharedWith is not null, return sharedKey
-    if (sharedWith != null && sharedWith!.isNotEmpty) {
-      return '$sharedWith:$key${_dotNamespaceIfPresent()}$sharedBy';
+    //If _sharedWith is not null, return sharedKey
+    if (_sharedWith != null && _sharedWith!.isNotEmpty) {
+      return '$_sharedWith:$key${_dotNamespaceIfPresent()}$_sharedBy';
     }
     // Defaults to return a self key.
-    return '$key${_dotNamespaceIfPresent()}$sharedBy';
+    return '$key${_dotNamespaceIfPresent()}$_sharedBy';
   }
 
+  static void assertStartsWithAtIfNotEmpty(String? atSign) {
+    if (atSign != null && atSign.isNotEmpty && !atSign.startsWith('@')) {
+      throw InvalidSyntaxException('atSign $atSign does not start with an "@"');
+    }
+  }
   /// Public keys are visible to everyone and shown in an authenticated/unauthenticated scan
   ///
   /// Builds a public key and returns a [PublicKeyBuilder]
@@ -60,6 +78,7 @@ class AtKey {
   ///```
   static PublicKeyBuilder public(String key,
       {String? namespace, String sharedBy = ''}) {
+    assertStartsWithAtIfNotEmpty(sharedBy);
     return PublicKeyBuilder()
       ..key(key)
       ..namespace(namespace)
@@ -67,7 +86,7 @@ class AtKey {
   }
 
   /// Shared Keys are shared with other atSign. The owner can see the keys on
-  /// authenticated scan. The SharedWith atSign can lookup the value of the key.
+  /// authenticated scan. The sharedWith atSign can lookup the value of the key.
   ///
   ///Builds a sharedWith key and returns a [SharedKeyBuilder]. Optionally the key
   ///can be cached on the [AtKey.sharedWith] atSign.
@@ -80,12 +99,13 @@ class AtKey {
   /// To cache a key on the @bob atSign.
   /// ```dart
   ///AtKey atKey = (AtKey.shared('phone', namespace: 'wavi', sharedBy: '@alice')
-  ///  ..sharedWith('bob')
+  ///  ..sharedWith('@bob')
   ///  ..cache(1000, true))
   ///  .build();
   /// ```
   static SharedKeyBuilder shared(String key,
       {String? namespace, String sharedBy = ''}) {
+    assertStartsWithAtIfNotEmpty(sharedBy);
     return SharedKeyBuilder()
       ..key(key)
       ..namespace(namespace)
@@ -104,6 +124,7 @@ class AtKey {
   /// ```
   static SelfKeyBuilder self(String key,
       {String? namespace, String sharedBy = ''}) {
+    assertStartsWithAtIfNotEmpty(sharedBy);
     return SelfKeyBuilder()
       ..key(key)
       ..namespace(namespace)
@@ -136,7 +157,7 @@ class AtKey {
       return atKey;
     } else if (key.startsWith(AT_ENCRYPTION_PRIVATE_KEY)) {
       atKey.key = key.split('@')[0];
-      atKey.sharedBy = '@${key.split('@')[1]}';
+      atKey._sharedBy = '@${key.split('@')[1]}';
       atKey.metadata = metaData;
       return atKey;
     }
@@ -148,7 +169,7 @@ class AtKey {
     // If key does not contain ':' Ex: phone@bob; then keyParts length is 1
     // where phone is key and @bob is sharedBy
     if (keyParts.length == 1) {
-      atKey.sharedBy = '@${keyParts[0].split('@')[1]}';
+      atKey._sharedBy = '@${keyParts[0].split('@')[1]}';
       atKey.key = keyParts[0].split('@')[0];
     } else {
       // Example key: public:phone@bob
@@ -158,9 +179,9 @@ class AtKey {
       // Example key: cached:@alice:phone@bob
       else if (keyParts[0] == CACHED) {
         metaData.isCached = true;
-        atKey.sharedWith = keyParts[1];
+        atKey._sharedWith = keyParts[1];
       } else {
-        atKey.sharedWith = keyParts[0];
+        atKey._sharedWith = keyParts[0];
       }
 
       List<String> keyArr = [];
@@ -170,7 +191,7 @@ class AtKey {
         keyArr = keyParts[1].split('@'); // phone@bob ==> 'phone', 'bob'
       }
       if (keyArr.length == 2) {
-        atKey.sharedBy = '@${keyArr[1]}'; // keyArr[1] is 'bob' so sharedBy needs to be @bob
+        atKey._sharedBy = '@${keyArr[1]}'; // keyArr[1] is 'bob' so sharedBy needs to be @bob
         atKey.key = keyArr[0];
       } else {
         atKey.key = keyArr[0];
@@ -200,7 +221,7 @@ class PublicKey extends AtKey {
 
   @override
   String toString() {
-    return 'public:$key${_dotNamespaceIfPresent()}$sharedBy';
+    return 'public:$key${_dotNamespaceIfPresent()}$_sharedBy';
   }
 }
 
@@ -216,10 +237,10 @@ class SelfKey extends AtKey {
     // If sharedWith is populated and sharedWith is equal to sharedBy, then
     // keys is a self key.
     // @alice:phone@alice or phone@alice
-    if (sharedWith != null && sharedWith!.isNotEmpty) {
-      return '$sharedWith:$key${_dotNamespaceIfPresent()}$sharedBy';
+    if (_sharedWith != null && _sharedWith!.isNotEmpty) {
+      return '$_sharedWith:$key${_dotNamespaceIfPresent()}$_sharedBy';
     }
-    return '$key${_dotNamespaceIfPresent()}$sharedBy';
+    return '$key${_dotNamespaceIfPresent()}$_sharedBy';
   }
 }
 
@@ -231,7 +252,7 @@ class SharedKey extends AtKey {
 
   @override
   String toString() {
-    return '$sharedWith:$key${_dotNamespaceIfPresent()}$sharedBy';
+    return '$_sharedWith:$key${_dotNamespaceIfPresent()}$_sharedBy';
   }
 }
 
@@ -243,7 +264,7 @@ class PrivateKey extends AtKey {
 
   @override
   String toString() {
-    return 'privatekey:$key';
+    return 'privatekey:$key${_dotNamespaceIfPresent()}';
   }
 }
 

--- a/at_commons/test/at_key_test.dart
+++ b/at_commons/test/at_key_test.dart
@@ -5,6 +5,31 @@ import 'package:test/test.dart';
 
 void main() {
   group('A group of positive test to construct a atKey', () {
+    test('toString and fromString with namespace', () {
+      var fromAtsign = '@alice';
+      var toAtsign = '@bob';
+      var metaData = Metadata()
+        ..isPublic = false
+        ..isEncrypted = true
+        ..namespaceAware = true
+        ..ttr = -1
+        ..ttl = 10000;
+
+      var inKey = AtKey()
+        ..key = 'foo.bar'
+        ..sharedBy = fromAtsign
+        ..sharedWith = toAtsign
+        ..namespace = 'attalk'
+        ..metadata = metaData;
+
+      expect(inKey.toString(), "@bob:foo.bar.attalk@alice");
+
+      var outKey = AtKey.fromString(inKey.toString());
+      expect(outKey.toString(), inKey.toString());
+      expect(outKey.key, 'foo.bar');
+      expect(outKey.namespace, 'attalk');
+    });
+
     test('Test to verify a public key', () {
       var testKey = 'public:phone@bob';
       var atKey = AtKey.fromString(testKey);

--- a/at_commons/test/at_key_test.dart
+++ b/at_commons/test/at_key_test.dart
@@ -6,51 +6,63 @@ import 'package:test/test.dart';
 void main() {
   group('A group of positive test to construct a atKey', () {
     test('Test to verify a public key', () {
-      var atKey = AtKey.fromString('public:phone@bob');
+      var testKey = 'public:phone@bob';
+      var atKey = AtKey.fromString(testKey);
       expect(atKey.key, 'phone');
-      expect(atKey.sharedBy, 'bob');
+      expect(atKey.sharedBy, '@bob');
       expect(atKey.metadata!.isPublic, true);
       expect(atKey.metadata!.namespaceAware, false);
+      expect(atKey.toString(), testKey);
     });
 
     test('Test to verify protected key', () {
-      var atKey = AtKey.fromString('@alice:phone@bob');
+      var testKey = '@alice:phone@bob';
+      var atKey = AtKey.fromString(testKey);
       expect(atKey.key, 'phone');
-      expect(atKey.sharedBy, 'bob');
+      expect(atKey.sharedBy, '@bob');
       expect(atKey.sharedWith, '@alice');
+      expect(atKey.toString(), testKey);
     });
 
     test('Test to verify private key', () {
-      var atKey = AtKey.fromString('phone@bob');
+      var testKey = 'phone@bob';
+      var atKey = AtKey.fromString(testKey);
       expect(atKey.key, 'phone');
-      expect(atKey.sharedBy, 'bob');
+      expect(atKey.sharedBy, '@bob');
+      expect(atKey.toString(), testKey);
     });
 
     test('Test to verify cached key', () {
-      var atKey = AtKey.fromString('cached:@alice:phone@bob');
+      var testKey = 'cached:@alice:phone@bob';
+      var atKey = AtKey.fromString(testKey);
       expect(atKey.key, 'phone');
-      expect(atKey.sharedBy, 'bob');
+      expect(atKey.sharedBy, '@bob');
       expect(atKey.sharedWith, '@alice');
       expect(atKey.metadata!.isCached, true);
       expect(atKey.metadata!.namespaceAware, false);
+      expect(atKey.toString(), testKey);
     });
 
     test('Test to verify pkam private key', () {
       var atKey = AtKey.fromString(AT_PKAM_PRIVATE_KEY);
       expect(atKey.key, AT_PKAM_PRIVATE_KEY);
+      expect(atKey.toString(), AT_PKAM_PRIVATE_KEY);
     });
 
     test('Test to verify pkam private key', () {
       var atKey = AtKey.fromString(AT_PKAM_PUBLIC_KEY);
       expect(atKey.key, AT_PKAM_PUBLIC_KEY);
+      expect(atKey.toString(), AT_PKAM_PUBLIC_KEY);
     });
 
     test('Test to verify key with namespace', () {
-      var atKey = AtKey.fromString('@alice:phone.buzz@bob');
+      var testKey = '@alice:phone.buzz@bob';
+      var atKey = AtKey.fromString(testKey);
       expect(atKey.key, 'phone');
       expect(atKey.sharedWith, '@alice');
-      expect(atKey.sharedBy, 'bob');
+      expect(atKey.sharedBy, '@bob');
       expect(atKey.metadata!.namespaceAware, true);
+      expect(atKey.toString(), testKey);
     });
   });
 
@@ -70,23 +82,41 @@ void main() {
       PublicKeyBuilder publicKeyBuilder =
           AtKey.public('phone', namespace: 'wavi');
       expect(publicKeyBuilder, isA<PublicKeyBuilder>());
+      expect(publicKeyBuilder.build().toString(), 'public:phone.wavi');
+
+      publicKeyBuilder =
+          AtKey.public('phone', namespace: 'wavi', sharedBy: '@alice');
+      expect(publicKeyBuilder, isA<PublicKeyBuilder>());
+      expect(publicKeyBuilder.build().toString(), 'public:phone.wavi@alice');
     });
 
     test('Validate the shared key builder', () {
       SharedKeyBuilder sharedKeyBuilder =
           AtKey.shared('phone', namespace: 'wavi')..sharedWith('@bob');
       expect(sharedKeyBuilder, isA<SharedKeyBuilder>());
+      expect(sharedKeyBuilder.build().toString(), '@bob:phone.wavi');
+
+      sharedKeyBuilder =
+          AtKey.shared('phone', namespace: 'wavi', sharedBy: '@alice')..sharedWith('@bob');
+      expect(sharedKeyBuilder, isA<SharedKeyBuilder>());
+      expect(sharedKeyBuilder.build().toString(), '@bob:phone.wavi@alice');
     });
 
     test('Validate the self key builder', () {
       SelfKeyBuilder selfKeyBuilder = AtKey.self('phone', namespace: 'wavi');
       expect(selfKeyBuilder, isA<SelfKeyBuilder>());
+      expect(selfKeyBuilder.build().toString(), 'phone.wavi');
+
+      selfKeyBuilder = AtKey.self('phone', namespace: 'wavi', sharedBy: '@bob');
+      expect(selfKeyBuilder, isA<SelfKeyBuilder>());
+      expect(selfKeyBuilder.build().toString(), 'phone.wavi@bob');
     });
 
     test('Validate the hidden key builder', () {
       PrivateKeyBuilder hiddenKeyBuilder =
           AtKey.private('phone', namespace: 'wavi');
       expect(hiddenKeyBuilder, isA<PrivateKeyBuilder>());
+      expect(hiddenKeyBuilder.build().toString(), 'privatekey:phone.wavi');
     });
   });
 
@@ -95,25 +125,29 @@ void main() {
       AtKey atKey =
           AtKey.public('phone', namespace: 'wavi', sharedBy: '@alice').build();
       expect(atKey, isA<PublicKey>());
+      expect(atKey.toString(), 'public:phone.wavi@alice');
     });
 
     test('Test to verify the shared key', () {
       AtKey atKey =
           (AtKey.shared('image', namespace: 'wavi', sharedBy: '@alice')
-                ..sharedWith('bob'))
+                ..sharedWith('@bob'))
               .build();
       expect(atKey, isA<SharedKey>());
+      expect(atKey.toString(), '@bob:image.wavi@alice');
     });
 
     test('Test to verify the self key', () {
       AtKey selfKey =
           AtKey.self('phone', namespace: 'wavi', sharedBy: '@alice').build();
       expect(selfKey, isA<SelfKey>());
+      expect(selfKey.toString(), 'phone.wavi@alice');
     });
 
     test('Test to verify the hidden key', () {
       AtKey selfKey = AtKey.private('phone', namespace: 'wavi').build();
       expect(selfKey, isA<PrivateKey>());
+      expect(selfKey.toString(), 'privatekey:phone.wavi');
     });
   });
 
@@ -148,6 +182,7 @@ void main() {
       expect(atKey.metadata!.isPublic, equals(true));
       expect(atKey.metadata!.isBinary, equals(false));
       expect(atKey.metadata!.isCached, equals(false));
+      expect(atKey.toString(), 'public:phone.wavi@alice');
     });
 
     test('Test key and namespace with ttl and ttb', () {
@@ -166,6 +201,7 @@ void main() {
       expect(atKey.metadata!.isPublic, equals(true));
       expect(atKey.metadata!.isBinary, equals(false));
       expect(atKey.metadata!.isCached, equals(false));
+      expect(atKey.toString(), 'public:phone.wavi@alice');
     });
   });
 
@@ -173,37 +209,39 @@ void main() {
     test('Test shared key without caching', () {
       AtKey atKey =
           (AtKey.shared('phone', namespace: 'wavi', sharedBy: '@alice')
-                ..sharedWith('bob'))
+                ..sharedWith('@bob'))
               .build();
 
       expect(atKey.key, equals('phone'));
       expect(atKey.sharedBy, equals('@alice'));
       expect(atKey.namespace, equals('wavi'));
-      expect(atKey.sharedWith, equals('bob'));
+      expect(atKey.sharedWith, equals('@bob'));
       expect(atKey.metadata!.ttl, equals(null));
       expect(atKey.metadata!.ttb, equals(null));
       expect(atKey.metadata!.isPublic, equals(false));
       expect(atKey.metadata!.isBinary, equals(false));
       expect(atKey.metadata!.isCached, equals(false));
+      expect(atKey.toString(), '@bob:phone.wavi@alice');
     });
 
     test('Test shared key with caching', () {
       AtKey atKey =
           (AtKey.shared('phone', namespace: 'wavi', sharedBy: '@alice')
-                ..sharedWith('bob')
+                ..sharedWith('@bob')
                 ..cache(1000, true))
               .build();
 
       expect(atKey.key, equals('phone'));
       expect(atKey.sharedBy, equals('@alice'));
       expect(atKey.namespace, equals('wavi'));
-      expect(atKey.sharedWith, equals('bob'));
+      expect(atKey.sharedWith, equals('@bob'));
       expect(atKey.metadata!.ttr, equals(1000));
       expect(atKey.metadata!.ccd, equals(true));
       expect(atKey.metadata!.ttl, equals(null));
       expect(atKey.metadata!.ttb, equals(null));
       expect(atKey.metadata!.isPublic, equals(false));
       expect(atKey.metadata!.isBinary, equals(false));
+      expect(atKey.toString(), '@bob:phone.wavi@alice');
     });
   });
 

--- a/at_dump_atKeys/pubspec.yaml
+++ b/at_dump_atKeys/pubspec.yaml
@@ -5,6 +5,9 @@ version: 1.0.0
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
+dependency_overrides:
+  at_pkam:
+    path: ../at_pkam
 dependencies:
   crypton: ^2.0.1
   encrypt: ^5.0.0


### PR DESCRIPTION
**- What I did**
fix: Fixed bug in AtKey.fromString() was stripping the leading '@' sign from the sharedBy when parsing any keys

fix: Fixed bugs in the various atKey.toString() instance methods which were all assuming presence of namespace and were therefore adding spurious '.null' when constructing string representation

fix: added validation : when setting sharedBy and sharedWith, if they are not null or empty, then they must start with '@'. Did this in AtKey class itself, and also in builders

test: made at_key_test tests stronger, added toString() assertions also

chore: updated pubspec.yaml in at_dump_atKeys so it picks up at_pkam locally

**- How I did it**
See code changes

I have also run unit tests in at_client against this branch, all of them pass

**- How to verify it**
Tests pass

**- Description for the changelog**
fix: bug fixes to AtKey.fromString static method and various toString instance methods