### PR TITLE
feat: Add AtKeyNotFoundException

### DIFF
--- a/at_commons/lib/src/exception/at_client_exceptions.dart
+++ b/at_commons/lib/src/exception/at_client_exceptions.dart
@@ -67,3 +67,10 @@ class SelfKeyNotFoundException extends AtDecryptionException {
       {Intent? intent, ExceptionScenario? exceptionScenario})
       : super(message, intent: intent, exceptionScenario: exceptionScenario);
 }
+
+class AtKeyNotFoundException extends AtClientException {
+  AtKeyNotFoundException(String message,
+      {Intent? intent, ExceptionScenario? exceptionScenario})
+      : super.message(message,
+            intent: intent, exceptionScenario: exceptionScenario);
+}

--- a/at_commons/lib/src/exception/at_exception_manager.dart
+++ b/at_commons/lib/src/exception/at_exception_manager.dart
@@ -3,10 +3,21 @@ import 'package:at_commons/at_commons.dart';
 /// AtExceptionManager is responsible for creating instances of the appropriate exception
 /// classes for a given exception scenario.
 class AtExceptionManager {
-  static AtException createException(AtException atException) {
+  /// This method is specific to client side exception handling.
+  /// Returns [AtClientException] or sub-class of [AtClientException]
+  static AtClientException createException(AtException atException) {
     // If the instance of atException is AtClientException. return as is.
     if (atException is AtClientException) {
       return atException;
+    }
+    // The KeyNotFoundException is a not a sub-class of AtClientException.
+    // Hence if the exception is triggered from the client side
+    // convert it to AtKeyNotFoundException and return it.
+    if (atException is KeyNotFoundException) {
+      return AtKeyNotFoundException(atException.message,
+              intent: atException.intent,
+              exceptionScenario: atException.exceptionScenario)
+          ..fromException(atException);
     }
     // Else wrap the atException into AtClientException and return.
     return (AtClientException.message(atException.message))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- With reference to the git issue [Issue-620](https://github.com/atsign-foundation/at_client_sdk/issues/620), Created a new exception 'AtKeyNotFoundException' as a subclass of AtClientException.
- When `KeyNotFoundException` is raised from the client side, convert it into `AtKeyNotFoundException` and return it.

**- How I did it**
- Created a new exception and updated the logic inside the `AtExceptionManager.createException`
- If atException is instance of `KeyNotFoundException` then convert the exception type as `AtKeyNotFoundException`

**- How to verify it**

- Fetch for a non existent key from the at_client. Assert that exception thrown is `AtKeyNotFoundException` and return it.

**- Description for the changelog**
- Add a new exception `AtKeyNotFoundException` 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->