### PR TITLE
feat: Atkey add getKeyType

### DIFF
--- a/at_commons/lib/at_commons.dart
+++ b/at_commons/lib/at_commons.dart
@@ -21,6 +21,7 @@ export 'package:at_commons/src/exception/at_exceptions.dart'
 export 'package:at_commons/src/exception/at_server_exceptions.dart';
 export 'package:at_commons/src/exception/error_message.dart';
 export 'package:at_commons/src/keystore/at_key.dart';
+export 'package:at_commons/src/keystore/key_type.dart';
 export 'package:at_commons/src/shared_key_status.dart';
 export 'package:at_commons/src/security/secure_socket_config.dart';
 export 'package:at_commons/src/validators/at_key_validation.dart';

--- a/at_commons/lib/src/at_constants.dart
+++ b/at_commons/lib/src/at_constants.dart
@@ -68,15 +68,4 @@ const String notificationCompactionKey =
 const String bypassCache = 'bypassCache';
 const String showHidden = 'showhidden';
 const String statsNotificationId = '_latestNotificationIdv2';
-const List<String> reservedKeys = [
-  commitLogCompactionKey,
-  accessLogCompactionKey,
-  notificationCompactionKey,
-  AT_PKAM_PRIVATE_KEY,
-  AT_PKAM_PUBLIC_KEY,
-  AT_ENCRYPTION_SELF_KEY,
-  AT_CRAM_SECRET,
-  AT_CRAM_SECRET_DELETED,
-  AT_SIGNING_KEYPAIR_GENERATED
-];
 const String ENCODING = 'encoding';

--- a/at_commons/lib/src/at_constants.dart
+++ b/at_commons/lib/src/at_constants.dart
@@ -68,3 +68,14 @@ const String notificationCompactionKey =
 const String bypassCache = 'bypassCache';
 const String showHidden = 'showhidden';
 const String statsNotificationId = '_latestNotificationIdv2';
+const List<String> reservedKeys = [
+  commitLogCompactionKey,
+  accessLogCompactionKey,
+  notificationCompactionKey,
+  AT_PKAM_PRIVATE_KEY,
+  AT_PKAM_PUBLIC_KEY,
+  AT_ENCRYPTION_SELF_KEY,
+  AT_CRAM_SECRET,
+  AT_CRAM_SECRET_DELETED,
+  AT_SIGNING_KEYPAIR_GENERATED
+];

--- a/at_commons/lib/src/exception/at_exceptions.dart
+++ b/at_commons/lib/src/exception/at_exceptions.dart
@@ -188,6 +188,11 @@ class InvalidResponseException extends AtException {
   InvalidResponseException(message) : super(message);
 }
 
+/// Exception thrown when a key is invalid
+class InvalidAtKeyException extends AtException {
+  InvalidAtKeyException(message) : super(message);
+}
+
 enum ExceptionScenario {
   noNetworkConnectivity,
   rootServerNotReachable,

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -250,7 +250,13 @@ class ReservedKey extends AtKey {
   static List<String> reservedKeys = [
     commitLogCompactionKey,
     accessLogCompactionKey,
-    notificationCompactionKey
+    notificationCompactionKey,
+    AT_PKAM_PRIVATE_KEY,
+    AT_PKAM_PUBLIC_KEY,
+    AT_ENCRYPTION_SELF_KEY,
+    AT_CRAM_SECRET,
+    AT_CRAM_SECRET_DELETED,
+    AT_SIGNING_KEYPAIR_GENERATED
   ];
 }
 

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -1,5 +1,7 @@
 import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/src/keystore/at_key_builder_impl.dart';
+import 'package:at_commons/src/keystore/key_type.dart';
+import 'package:at_commons/src/utils/at_key_regex_utils.dart';
 
 class AtKey {
   String? key;
@@ -180,6 +182,10 @@ class AtKey {
     }
     atKey.metadata = metaData;
     return atKey;
+  }
+
+  static KeyType getKeyType(String key) {
+    return RegexUtil.keyType(key);
   }
 }
 

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -184,6 +184,7 @@ class AtKey {
     return atKey;
   }
 
+  //# TODO dartdocs
   static KeyType getKeyType(String key) {
     return RegexUtil.keyType(key);
   }
@@ -243,6 +244,14 @@ class PrivateKey extends AtKey {
   String toString() {
     return 'privatekey:$key';
   }
+}
+
+class ReservedKey extends AtKey {
+  static List<String> reservedKeys = [
+    commitLogCompactionKey,
+    accessLogCompactionKey,
+    notificationCompactionKey
+  ];
 }
 
 class Metadata {

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -246,20 +246,6 @@ class PrivateKey extends AtKey {
   }
 }
 
-class ReservedKey extends AtKey {
-  static List<String> reservedKeys = [
-    commitLogCompactionKey,
-    accessLogCompactionKey,
-    notificationCompactionKey,
-    AT_PKAM_PRIVATE_KEY,
-    AT_PKAM_PUBLIC_KEY,
-    AT_ENCRYPTION_SELF_KEY,
-    AT_CRAM_SECRET,
-    AT_CRAM_SECRET_DELETED,
-    AT_SIGNING_KEYPAIR_GENERATED
-  ];
-}
-
 class Metadata {
   int? ttl;
   int? ttb;

--- a/at_commons/lib/src/keystore/key_type.dart
+++ b/at_commons/lib/src/keystore/key_type.dart
@@ -9,7 +9,7 @@ enum KeyType {
   invalidKey
 }
 
-enum ReservedKeys {
+enum ReservedKey {
   encryptionSharedKey,
   encryptionPublicKey,
   encryptionPrivateKey,

--- a/at_commons/lib/src/keystore/key_type.dart
+++ b/at_commons/lib/src/keystore/key_type.dart
@@ -5,6 +5,7 @@ enum KeyType {
   privateKey,
   cachedPublicKey,
   cachedSharedKey,
+  reservedKey,
   invalidKey
 }
 

--- a/at_commons/lib/src/keystore/key_type.dart
+++ b/at_commons/lib/src/keystore/key_type.dart
@@ -9,7 +9,7 @@ enum KeyType {
   invalidKey
 }
 
-enum ReservedKey {
+enum ReservedKeys {
   encryptionSharedKey,
   encryptionPublicKey,
   encryptionPrivateKey,

--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -22,7 +22,7 @@ abstract class Regexes {
   static const String sharedKeyStartFragment = '''((@$sharedWithFragment)(_*$entityFragment)''';
   static const String cachedSharedKeyStartFragment = '''((cached:)(@$sharedWithFragment)(_*$entityFragment)''';
   static const String cachedPublicKeyStartFragment = '''(?<visibility>(cached:public:){1})((@$sharedWithFragment)?$entityFragment''';
-  static const String reservedKey = '''(((@(?<sharedWith>($charsInAtSign|$allowedEmoji){1,55}))|public|privatekey):)?(?<atKey>$_charsInReservedKey)(@(?<owner>($charsInAtSign|$allowedEmoji){1,55}))?''';
+  static const String reservedKeyFragment = '''(((@(?<sharedWith>($charsInAtSign|$allowedEmoji){1,55}))|public|privatekey):)?(?<atKey>$_charsInReservedKey)(@(?<owner>($charsInAtSign|$allowedEmoji){1,55}))?''';
 
   String get publicKey;
   String get privateKey;
@@ -30,6 +30,7 @@ abstract class Regexes {
   String get sharedKey;
   String get cachedSharedKey;
   String get cachedPublicKey;
+  String get reservedKey;
 
   static final Regexes _regexesWithMandatoryNamespace = RegexesWithMandatoryNamespace();
   static final Regexes _regexesNonMandatoryNamespace = RegexesNonMandatoryNamespace();
@@ -69,6 +70,9 @@ class RegexesWithMandatoryNamespace implements Regexes {
 
   @override
   String get cachedPublicKey => _cachedPublicKey;
+
+  @override
+  String get reservedKey => Regexes.reservedKeyFragment;
 }
 
 class RegexesNonMandatoryNamespace implements Regexes {
@@ -97,6 +101,9 @@ class RegexesNonMandatoryNamespace implements Regexes {
 
   @override
   String get cachedPublicKey => _cachedPublicKey;
+
+  @override
+  String get reservedKey => Regexes.reservedKeyFragment;
 }
 
 class RegexUtil {
@@ -104,7 +111,7 @@ class RegexUtil {
   static KeyType keyType(String key, bool enforceNamespace) {
     Regexes regexes = Regexes(enforceNamespace);
 
-    if (matchAll(Regexes.reservedKey, key)) {
+    if (matchAll(regexes.reservedKey, key)) {
       return KeyType.reservedKey;
     }
 

--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -4,6 +4,9 @@ import 'package:at_commons/src/at_constants.dart';
 import 'package:at_commons/src/keystore/key_type.dart';
 
 class Regexes {
+  // The regex [_\w-]+ is used to match the session keys (example: _a7abf9f5-dde5-4320-918e-c71760b88641)
+  static const _charsInReservedKey =
+      r'(shared_key|publickey|privatekey|self_encryption_key|commitLogCompactionStats|accessLogCompactionStats|notificationCompactionStats|signing_privatekey|signing_publickey|signing_keypair_generated|at_pkam_privatekey|at_pkam_publickey|at_secret|at_secret_deleted|_[\w-]+|)';
   static const _charsInNamespace = r'([\w])+';
   static const _charsInAtSign = r'[\w\-_]';
   static const _charsInEntity = r'''[\w\.\-_'*"]''';
@@ -24,13 +27,13 @@ class Regexes {
   static const cachedPublicKey =
       '''(?<visibility>(cached:public:){1})((@(?<sharedWith>($_charsInAtSign|$_allowedEmoji){1,55}):))?(?<entity>($_charsInEntity|$_allowedEmoji)+)\\.(?<namespace>$_charsInNamespace)@(?<owner>($_charsInAtSign|$_allowedEmoji){1,55})''';
   static const reservedKey =
-      '^($commitLogCompactionKey|$accessLogCompactionKey|$notificationCompactionKey|$AT_PKAM_PRIVATE_KEY|$AT_PKAM_PUBLIC_KEY|$AT_ENCRYPTION_SELF_KEY|$AT_CRAM_SECRET|$AT_CRAM_SECRET_DELETED|$AT_SIGNING_KEYPAIR_GENERATED)\$';
+      '''(((@(?<sharedWith>($_charsInAtSign|$_allowedEmoji){1,55}))|public|privatekey):)?(?<atKey>$_charsInReservedKey)(@(?<owner>($_charsInAtSign|$_allowedEmoji){1,55}))?''';
 }
 
 class RegexUtil {
   /// Returns a first matching key type after matching the key against regexes for each of the key type
   static KeyType keyType(String key) {
-    if (reservedKeys.contains(key)) {
+    if (matchAll(Regexes.reservedKey, key)) {
       return KeyType.reservedKey;
     }
     // matches the key with public key regex.

--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 
+import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/src/keystore/key_type.dart';
 import 'package:at_commons/src/keystore/at_key.dart';
 
@@ -23,6 +24,8 @@ class Regexes {
       '''((cached:)(@(?<sharedWith>($_charsInAtSign|$_allowedEmoji){1,55}):))(_*(?<entity>($_charsInEntity|$_allowedEmoji)+))\\.(?<namespace>$_charsInNamespace)@(?<owner>($_charsInAtSign|$_allowedEmoji){1,55})''';
   static const cachedPublicKey =
       '''(?<visibility>(cached:public:){1})((@(?<sharedWith>($_charsInAtSign|$_allowedEmoji){1,55}):))?(?<entity>($_charsInEntity|$_allowedEmoji)+)\\.(?<namespace>$_charsInNamespace)@(?<owner>($_charsInAtSign|$_allowedEmoji){1,55})''';
+  static const reservedKey =
+      '^($commitLogCompactionKey|$accessLogCompactionKey|$notificationCompactionKey|$AT_PKAM_PRIVATE_KEY|$AT_PKAM_PUBLIC_KEY|$AT_ENCRYPTION_SELF_KEY|$AT_CRAM_SECRET|$AT_CRAM_SECRET_DELETED|$AT_SIGNING_KEYPAIR_GENERATED)\$';
 }
 
 class RegexUtil {

--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -6,8 +6,10 @@ abstract class Regexes {
   static const charsInNamespace = r'([\w])+';
   static const charsInAtSign = r'[\w\-_]';
   static const charsInEntity = r'''[\w\.\-_'*"]''';
-  static const allowedEmoji = r'''((\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))''';
-  static const _charsInReservedKey = r'(shared_key|publickey|privatekey|self_encryption_key|commitLogCompactionStats|accessLogCompactionStats|notificationCompactionStats|signing_privatekey|signing_publickey|signing_keypair_generated|at_pkam_privatekey|at_pkam_publickey|at_secret_deleted|at_secret|_[\w-]+|)';
+  static const allowedEmoji =
+      r'''((\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))''';
+  static const _charsInReservedKey =
+      r'(shared_key|publickey|privatekey|self_encryption_key|commitLogCompactionStats|accessLogCompactionStats|notificationCompactionStats|signing_privatekey|signing_publickey|signing_keypair_generated|at_pkam_privatekey|at_pkam_publickey|at_secret_deleted|at_secret|_[\w-]+|)';
 
   static const String namespaceFragment = '''\\.(?<namespace>$charsInNamespace)''';
   static const String ownershipFragment = '''@(?<owner>($charsInAtSign|$allowedEmoji){1,55})''';

--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -9,7 +9,7 @@ abstract class Regexes {
   static const allowedEmoji =
       r'''((\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))''';
   static const _charsInReservedKey =
-      r'(shared_key|publickey|privatekey|self_encryption_key|commitLogCompactionStats|accessLogCompactionStats|notificationCompactionStats|signing_privatekey|signing_publickey|signing_keypair_generated|at_pkam_privatekey|at_pkam_publickey|at_secret|at_secret_deleted|_[\w-]+|)';
+      r'(shared_key|publickey|privatekey|self_encryption_key|commitLogCompactionStats|accessLogCompactionStats|notificationCompactionStats|signing_privatekey|signing_publickey|signing_keypair_generated|at_pkam_privatekey|at_pkam_publickey|at_secret_deleted|at_secret|_[\w-]+|)';
 
   static const String namespaceFragment =
       '''\\.(?<namespace>$charsInNamespace)''';

--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 
 import 'package:at_commons/src/keystore/key_type.dart';
+import 'package:at_commons/src/keystore/at_key.dart';
 
 class Regexes {
   static const _charsInNamespace = r'([\w])+';
@@ -27,6 +28,9 @@ class Regexes {
 class RegexUtil {
   /// Returns a first matching key type after matching the key against regexes for each of the key type
   static KeyType keyType(String key) {
+    if (ReservedKey.reservedKeys.contains(key)) {
+      return KeyType.reservedKey;
+    }
     // matches the key with public key regex.
     if (matchAll(Regexes.publicKey, key)) {
       return KeyType.publicKey;

--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -1,8 +1,7 @@
 import 'dart:collection';
 
-import 'package:at_commons/at_commons.dart';
+import 'package:at_commons/src/at_constants.dart';
 import 'package:at_commons/src/keystore/key_type.dart';
-import 'package:at_commons/src/keystore/at_key.dart';
 
 class Regexes {
   static const _charsInNamespace = r'([\w])+';
@@ -31,7 +30,7 @@ class Regexes {
 class RegexUtil {
   /// Returns a first matching key type after matching the key against regexes for each of the key type
   static KeyType keyType(String key) {
-    if (ReservedKey.reservedKeys.contains(key)) {
+    if (reservedKeys.contains(key)) {
       return KeyType.reservedKey;
     }
     // matches the key with public key regex.

--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -6,34 +6,21 @@ abstract class Regexes {
   static const charsInNamespace = r'([\w])+';
   static const charsInAtSign = r'[\w\-_]';
   static const charsInEntity = r'''[\w\.\-_'*"]''';
-  static const allowedEmoji =
-      r'''((\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))''';
-  static const _charsInReservedKey =
-      r'(shared_key|publickey|privatekey|self_encryption_key|commitLogCompactionStats|accessLogCompactionStats|notificationCompactionStats|signing_privatekey|signing_publickey|signing_keypair_generated|at_pkam_privatekey|at_pkam_publickey|at_secret_deleted|at_secret|_[\w-]+|)';
+  static const allowedEmoji = r'''((\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))''';
+  static const _charsInReservedKey = r'(shared_key|publickey|privatekey|self_encryption_key|commitLogCompactionStats|accessLogCompactionStats|notificationCompactionStats|signing_privatekey|signing_publickey|signing_keypair_generated|at_pkam_privatekey|at_pkam_publickey|at_secret_deleted|at_secret|_[\w-]+|)';
 
-  static const String namespaceFragment =
-      '''\\.(?<namespace>$charsInNamespace)''';
-  static const String ownershipFragment =
-      '''@(?<owner>($charsInAtSign|$allowedEmoji){1,55})''';
-  static const String sharedWithFragment =
-      '''(?<sharedWith>($charsInAtSign|$allowedEmoji){1,55}):)''';
-  static const String entityFragment =
-      '''(?<entity>($charsInEntity|$allowedEmoji)+)''';
+  static const String namespaceFragment = '''\\.(?<namespace>$charsInNamespace)''';
+  static const String ownershipFragment = '''@(?<owner>($charsInAtSign|$allowedEmoji){1,55})''';
+  static const String sharedWithFragment = '''(?<sharedWith>($charsInAtSign|$allowedEmoji){1,55}):)''';
+  static const String entityFragment = '''(?<entity>($charsInEntity|$allowedEmoji)+)''';
 
-  static const String publicKeyStartFragment =
-      '''(?<visibility>(public:){1})((@$sharedWithFragment)?$entityFragment''';
-  static const String privateKeyStartFragment =
-      '''(?<visibility>(private:){1})((@$sharedWithFragment)?$entityFragment''';
-  static const String selfKeyStartFragment =
-      '''((@$sharedWithFragment)?(_*$entityFragment)''';
-  static const String sharedKeyStartFragment =
-      '''((@$sharedWithFragment)(_*$entityFragment)''';
-  static const String cachedSharedKeyStartFragment =
-      '''((cached:)(@$sharedWithFragment)(_*$entityFragment)''';
-  static const String cachedPublicKeyStartFragment =
-      '''(?<visibility>(cached:public:){1})((@$sharedWithFragment)?$entityFragment''';
-  static const reservedKey =
-      '''(((@(?<sharedWith>($charsInAtSign|$allowedEmoji){1,55}))|public|privatekey):)?(?<atKey>$_charsInReservedKey)(@(?<owner>($charsInAtSign|$allowedEmoji){1,55}))?''';
+  static const String publicKeyStartFragment = '''(?<visibility>(public:){1})((@$sharedWithFragment)?$entityFragment''';
+  static const String privateKeyStartFragment = '''(?<visibility>(private:){1})((@$sharedWithFragment)?$entityFragment''';
+  static const String selfKeyStartFragment = '''((@$sharedWithFragment)?(_*$entityFragment)''';
+  static const String sharedKeyStartFragment = '''((@$sharedWithFragment)(_*$entityFragment)''';
+  static const String cachedSharedKeyStartFragment = '''((cached:)(@$sharedWithFragment)(_*$entityFragment)''';
+  static const String cachedPublicKeyStartFragment = '''(?<visibility>(cached:public:){1})((@$sharedWithFragment)?$entityFragment''';
+  static const String reservedKey = '''(((@(?<sharedWith>($charsInAtSign|$allowedEmoji){1,55}))|public|privatekey):)?(?<atKey>$_charsInReservedKey)(@(?<owner>($charsInAtSign|$allowedEmoji){1,55}))?''';
 
   String get publicKey;
   String get privateKey;
@@ -42,10 +29,8 @@ abstract class Regexes {
   String get cachedSharedKey;
   String get cachedPublicKey;
 
-  static final Regexes _regexesWithMandatoryNamespace =
-      RegexesWithMandatoryNamespace();
-  static final Regexes _regexesNonMandatoryNamespace =
-      RegexesNonMandatoryNamespace();
+  static final Regexes _regexesWithMandatoryNamespace = RegexesWithMandatoryNamespace();
+  static final Regexes _regexesNonMandatoryNamespace = RegexesNonMandatoryNamespace();
 
   factory Regexes(bool enforceNamespace) {
     if (enforceNamespace) {
@@ -58,18 +43,12 @@ abstract class Regexes {
 
 class RegexesWithMandatoryNamespace implements Regexes {
   // There are currently no tests for this, but the regexes are and must remain mutually exclusive
-  static const String _publicKey =
-      '''${Regexes.publicKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
-  static const String _privateKey =
-      '''${Regexes.privateKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
-  static const String _selfKey =
-      '''${Regexes.selfKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
-  static const String _sharedKey =
-      '''${Regexes.sharedKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
-  static const String _cachedSharedKey =
-      '''${Regexes.cachedSharedKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
-  static const String _cachedPublicKey =
-      '''${Regexes.cachedPublicKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _publicKey = '''${Regexes.publicKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _privateKey = '''${Regexes.privateKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _selfKey = '''${Regexes.selfKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _sharedKey = '''${Regexes.sharedKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _cachedSharedKey = '''${Regexes.cachedSharedKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _cachedPublicKey = '''${Regexes.cachedPublicKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
 
   @override
   String get publicKey => _publicKey;
@@ -92,18 +71,12 @@ class RegexesWithMandatoryNamespace implements Regexes {
 
 class RegexesNonMandatoryNamespace implements Regexes {
   // There are currently no tests for this, but the regexes are and must remain mutually exclusive
-  static const String _publicKey =
-      '''${Regexes.publicKeyStartFragment}${Regexes.ownershipFragment}''';
-  static const String _privateKey =
-      '''${Regexes.privateKeyStartFragment}${Regexes.ownershipFragment}''';
-  static const String _selfKey =
-      '''${Regexes.selfKeyStartFragment}${Regexes.ownershipFragment}''';
-  static const String _sharedKey =
-      '''${Regexes.sharedKeyStartFragment}${Regexes.ownershipFragment}''';
-  static const String _cachedSharedKey =
-      '''${Regexes.cachedSharedKeyStartFragment}${Regexes.ownershipFragment}''';
-  static const String _cachedPublicKey =
-      '''${Regexes.cachedPublicKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _publicKey = '''${Regexes.publicKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _privateKey = '''${Regexes.privateKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _selfKey = '''${Regexes.selfKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _sharedKey = '''${Regexes.sharedKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _cachedSharedKey = '''${Regexes.cachedSharedKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _cachedPublicKey = '''${Regexes.cachedPublicKeyStartFragment}${Regexes.ownershipFragment}''';
 
   @override
   String get publicKey => _publicKey;

--- a/at_commons/lib/src/validators/at_key_validation_impl.dart
+++ b/at_commons/lib/src/validators/at_key_validation_impl.dart
@@ -84,8 +84,7 @@ class _AtKeyValidatorImpl extends AtKeyValidator {
         _regex = Regexes.cachedSharedKey;
         break;
       case KeyType.reservedKey:
-        // #TODO implement reservedKey
-        _regex = '';
+        _regex = Regexes.reservedKey;
         break;
       case KeyType.invalidKey:
         _regex = '';

--- a/at_commons/lib/src/validators/at_key_validation_impl.dart
+++ b/at_commons/lib/src/validators/at_key_validation_impl.dart
@@ -81,7 +81,7 @@ class _AtKeyValidatorImpl extends AtKeyValidator {
         _regex = regexes.cachedSharedKey;
         break;
       case KeyType.reservedKey:
-        _regex = Regexes.reservedKey;
+        _regex = regexes.reservedKey;
         break;
       case KeyType.invalidKey:
         _regex = '';

--- a/at_commons/lib/src/validators/at_key_validation_impl.dart
+++ b/at_commons/lib/src/validators/at_key_validation_impl.dart
@@ -83,6 +83,10 @@ class _AtKeyValidatorImpl extends AtKeyValidator {
       case KeyType.cachedSharedKey:
         _regex = Regexes.cachedSharedKey;
         break;
+      case KeyType.reservedKey:
+        // #TODO implement reservedKey
+        _regex = '';
+        break;
       case KeyType.invalidKey:
         _regex = '';
         break;

--- a/at_commons/lib/src/validators/at_key_validation_impl.dart
+++ b/at_commons/lib/src/validators/at_key_validation_impl.dart
@@ -104,31 +104,31 @@ class ReservedEntityValidation extends Validation {
   ValidationResult doValidate() {
     // If key is in reserved key list, return false.
     var reservedKey = _reservedKey(key);
-    if (reservedKey != ReservedKey.nonReservedKey &&
-        ReservedKey.values.contains(reservedKey)) {
+    if (reservedKey != ReservedKeys.nonReservedKey &&
+        ReservedKeys.values.contains(reservedKey)) {
       return ValidationResult('Reserved key cannot be created');
     }
     return ValidationResult.noFailure();
   }
 
-  /// Returns the [ReservedKey] enum for given key.
-  ReservedKey _reservedKey(String key) {
+  /// Returns the [ReservedKeys] enum for given key.
+  ReservedKeys _reservedKey(String key) {
     if (key == _getEntityFromConstant(AT_ENCRYPTION_SHARED_KEY)) {
-      return ReservedKey.encryptionSharedKey;
+      return ReservedKeys.encryptionSharedKey;
     }
     if (key == _getEntityFromConstant(AT_ENCRYPTION_PUBLIC_KEY)) {
-      return ReservedKey.encryptionPublicKey;
+      return ReservedKeys.encryptionPublicKey;
     }
     if (key == _getEntityFromConstant(AT_ENCRYPTION_PRIVATE_KEY)) {
-      return ReservedKey.encryptionPrivateKey;
+      return ReservedKeys.encryptionPrivateKey;
     }
     if (key == _getEntityFromConstant(AT_PKAM_PUBLIC_KEY)) {
-      return ReservedKey.pkamPublicKey;
+      return ReservedKeys.pkamPublicKey;
     }
     if (key == _getEntityFromConstant(AT_SIGNING_PRIVATE_KEY)) {
-      return ReservedKey.signingPrivateKey;
+      return ReservedKeys.signingPrivateKey;
     }
-    return ReservedKey.nonReservedKey;
+    return ReservedKeys.nonReservedKey;
   }
 
   /// Returns the entity part from the key constants.

--- a/at_commons/lib/src/validators/at_key_validation_impl.dart
+++ b/at_commons/lib/src/validators/at_key_validation_impl.dart
@@ -103,31 +103,31 @@ class ReservedEntityValidation extends Validation {
   ValidationResult doValidate() {
     // If key is in reserved key list, return false.
     var reservedKey = _reservedKey(key);
-    if (reservedKey != ReservedKeys.nonReservedKey &&
-        ReservedKeys.values.contains(reservedKey)) {
+    if (reservedKey != ReservedKey.nonReservedKey &&
+        ReservedKey.values.contains(reservedKey)) {
       return ValidationResult('Reserved key cannot be created');
     }
     return ValidationResult.noFailure();
   }
 
-  /// Returns the [ReservedKeys] enum for given key.
-  ReservedKeys _reservedKey(String key) {
+  /// Returns the [ReservedKey] enum for given key.
+  ReservedKey _reservedKey(String key) {
     if (key == _getEntityFromConstant(AT_ENCRYPTION_SHARED_KEY)) {
-      return ReservedKeys.encryptionSharedKey;
+      return ReservedKey.encryptionSharedKey;
     }
     if (key == _getEntityFromConstant(AT_ENCRYPTION_PUBLIC_KEY)) {
-      return ReservedKeys.encryptionPublicKey;
+      return ReservedKey.encryptionPublicKey;
     }
     if (key == _getEntityFromConstant(AT_ENCRYPTION_PRIVATE_KEY)) {
-      return ReservedKeys.encryptionPrivateKey;
+      return ReservedKey.encryptionPrivateKey;
     }
     if (key == _getEntityFromConstant(AT_PKAM_PUBLIC_KEY)) {
-      return ReservedKeys.pkamPublicKey;
+      return ReservedKey.pkamPublicKey;
     }
     if (key == _getEntityFromConstant(AT_SIGNING_PRIVATE_KEY)) {
-      return ReservedKeys.signingPrivateKey;
+      return ReservedKey.signingPrivateKey;
     }
-    return ReservedKeys.nonReservedKey;
+    return ReservedKey.nonReservedKey;
   }
 
   /// Returns the entity part from the key constants.

--- a/at_commons/test/at_key_type_test.dart
+++ b/at_commons/test/at_key_type_test.dart
@@ -1,0 +1,63 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:at_commons/src/keystore/key_type.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests to verify key types', () {
+    // test('Test to verify a public key type', () {
+    //   var keyType = AtKey.getKeyType('public:phone@bob');
+    //   expect(keyType, equals(KeyType.publicKey));
+    //
+    // });
+    //
+    // test('Test to verify a cached public key type', () {
+    //   var keyType = AtKey.getKeyType('cached:public:phone@bob');
+    //   expect(keyType, equals(KeyType.cachedPublicKey));
+    //
+    // });
+    //
+    // test('Test to verify a shared key type', () {
+    //   var keyType = AtKey.getKeyType('@alice:phone@bob');
+    //   expect(keyType, equals(KeyType.sharedKey));
+    // });
+    //
+    // test('Test to verify a cached shared key type', () {
+    //   var keyType = AtKey.getKeyType('cached:@alice:phone@bob');
+    //   expect(keyType, equals(KeyType.cachedSharedKey));
+    // });
+    //
+    // test('Test to verify self key type without sharedWith atsign', () {
+    //   var keyType = AtKey.getKeyType('phone@bob');
+    //   expect(keyType, equals(KeyType.selfKey));
+    // });
+    // test('Test to verify self key type with atsign', () {
+    //   var keyType = AtKey.getKeyType('@bob:phone@bob');
+    //   expect(keyType, equals(KeyType.selfKey));
+    // });
+
+    test('Test to verify a public key type with namespace', () {
+      var keyType = AtKey.getKeyType('public:phone.wavi@bob');
+      expect(keyType, equals(KeyType.publicKey));
+    });
+
+    test('Test to verify a cached public key type with namespace', () {
+      var keyType = AtKey.getKeyType('cached:public:phone.buzz@bob');
+      expect(keyType, equals(KeyType.cachedPublicKey));
+    });
+
+    test('Test to verify a shared key type with namespace', () {
+      var keyType = AtKey.getKeyType('@alice:phone.wavi@bob');
+      expect(keyType, equals(KeyType.sharedKey));
+    });
+
+    test('Test to verify a cached shared key type with namespace', () {
+      var keyType = AtKey.getKeyType('cached:@alice:phone.buzz@bob');
+      expect(keyType, equals(KeyType.cachedSharedKey));
+    });
+
+    test('Test to verify self key type with namespace', () {
+      var keyType = AtKey.getKeyType('@bob:phone.buzz@bob');
+      expect(keyType, equals(KeyType.selfKey));
+    });
+  });
+}

--- a/at_commons/test/at_key_type_test.dart
+++ b/at_commons/test/at_key_type_test.dart
@@ -4,37 +4,6 @@ import 'package:test/test.dart';
 
 void main() {
   group('A group of tests to verify key types', () {
-    // test('Test to verify a public key type', () {
-    //   var keyType = AtKey.getKeyType('public:phone@bob');
-    //   expect(keyType, equals(KeyType.publicKey));
-    //
-    // });
-    //
-    // test('Test to verify a cached public key type', () {
-    //   var keyType = AtKey.getKeyType('cached:public:phone@bob');
-    //   expect(keyType, equals(KeyType.cachedPublicKey));
-    //
-    // });
-    //
-    // test('Test to verify a shared key type', () {
-    //   var keyType = AtKey.getKeyType('@alice:phone@bob');
-    //   expect(keyType, equals(KeyType.sharedKey));
-    // });
-    //
-    // test('Test to verify a cached shared key type', () {
-    //   var keyType = AtKey.getKeyType('cached:@alice:phone@bob');
-    //   expect(keyType, equals(KeyType.cachedSharedKey));
-    // });
-    //
-    // test('Test to verify self key type without sharedWith atsign', () {
-    //   var keyType = AtKey.getKeyType('phone@bob');
-    //   expect(keyType, equals(KeyType.selfKey));
-    // });
-    // test('Test to verify self key type with atsign', () {
-    //   var keyType = AtKey.getKeyType('@bob:phone@bob');
-    //   expect(keyType, equals(KeyType.selfKey));
-    // });
-
     test('Test to verify a public key type with namespace', () {
       var keyType = AtKey.getKeyType('public:phone.wavi@bob');
       expect(keyType, equals(KeyType.publicKey));
@@ -58,6 +27,37 @@ void main() {
     test('Test to verify self key type with namespace', () {
       var keyType = AtKey.getKeyType('@bob:phone.buzz@bob');
       expect(keyType, equals(KeyType.selfKey));
+    });
+  });
+  group('A group of tests to check invalid key types', () {
+    test('Test public key type without namespace', () {
+      var keyType = AtKey.getKeyType('public:phone@bob');
+      expect(keyType, equals(KeyType.invalidKey));
+    });
+
+    test('Test cached public key type without namespace', () {
+      var keyType = AtKey.getKeyType('cached:public:phone@bob');
+      expect(keyType, equals(KeyType.invalidKey));
+    });
+
+    test('Test shared key type without namespace', () {
+      var keyType = AtKey.getKeyType('@alice:phone@bob');
+      expect(keyType, equals(KeyType.invalidKey));
+    });
+
+    test('Test cached shared key type without namespace', () {
+      var keyType = AtKey.getKeyType('cached:@alice:phone@bob');
+      expect(keyType, equals(KeyType.invalidKey));
+    });
+
+    test('Test self key type without sharedWith atsign and without namespace',
+        () {
+      var keyType = AtKey.getKeyType('phone@bob');
+      expect(keyType, equals(KeyType.invalidKey));
+    });
+    test('Test self key type with atsign and without namespace', () {
+      var keyType = AtKey.getKeyType('@bob:phone@bob');
+      expect(keyType, equals(KeyType.invalidKey));
     });
   });
 }

--- a/at_commons/test/at_key_type_test.dart
+++ b/at_commons/test/at_key_type_test.dart
@@ -59,5 +59,31 @@ void main() {
       var keyType = AtKey.getKeyType('@bob:phone@bob');
       expect(keyType, equals(KeyType.invalidKey));
     });
+
+    test('Test reserved key type for shared_key', () {
+      var keyType = AtKey.getKeyType('@bob:shared_key@alice');
+      expect(keyType, equals(KeyType.reservedKey));
+    });
+
+    test('Test reserved key type for encryption publickey', () {
+      var keyType = AtKey.getKeyType('public:publickey@alice');
+      expect(keyType, equals(KeyType.reservedKey));
+    });
+
+    test('Test reserved key type for public session key', () {
+      var keyType = AtKey.getKeyType(
+          'public:_a29464d0-1f2d-4216-b903-031963bc4ab3@alice');
+      expect(keyType, equals(KeyType.reservedKey));
+    });
+
+    test('Test reserved key type for latest notification id', () {
+      var keyType = AtKey.getKeyType('_latestNotificationIdv2');
+      expect(keyType, equals(KeyType.reservedKey));
+    });
+
+    test('Test reserved key type for signing public key', () {
+      var keyType = AtKey.getKeyType('public:signing_publickey@colin');
+      expect(keyType, equals(KeyType.reservedKey));
+    });
   });
 }


### PR DESCRIPTION
**- What I did**
- added support in AtKey for validation method in persistence layer
**- How I did it**
- added a new method getKeyType which will return a valid key type enum from KeyType
- added a new enum value reservedKey. 
- added  new exception InvalidAtKeyException
- exported key_type.dart from at_commons
**- How to verify it**
- run the unit tests at_key_type_test.dart
