### PR TITLE
feat: add clientConfig to from verb

### DIFF
--- a/at_commons/lib/at_builders.dart
+++ b/at_commons/lib/at_builders.dart
@@ -18,3 +18,4 @@ export 'package:at_commons/src/verb/sync_verb_builder.dart';
 export 'package:at_commons/src/verb/syntax.dart';
 export 'package:at_commons/src/verb/update_verb_builder.dart';
 export 'package:at_commons/src/verb/verb_builder.dart';
+export 'package:at_commons/src/verb/from_verb_builder.dart';

--- a/at_commons/lib/src/at_constants.dart
+++ b/at_commons/lib/src/at_constants.dart
@@ -69,3 +69,5 @@ const String bypassCache = 'bypassCache';
 const String showHidden = 'showhidden';
 const String statsNotificationId = '_latestNotificationIdv2';
 const String ENCODING = 'encoding';
+const String CLIENT_CONFIG = 'clientConfig';
+const String VERSION = 'version';

--- a/at_commons/lib/src/verb/from_verb_builder.dart
+++ b/at_commons/lib/src/verb/from_verb_builder.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:at_commons/at_builders.dart';
+import 'package:at_commons/at_commons.dart';
+
+class FromVerbBuilder implements VerbBuilder {
+  late String atSign;
+
+  /// Stores the client configurations. Defaults to empty Map.
+  Map<String, dynamic> clientConfig = {};
+
+  @override
+  String buildCommand() {
+    var command = 'from:$atSign';
+    if (clientConfig.isNotEmpty) {
+      var clientConfigStr = jsonEncode(clientConfig);
+      command += ':$CLIENT_CONFIG:$clientConfigStr';
+    }
+    command += '\n';
+    return command;
+  }
+
+  @override
+  bool checkParams() {
+    return atSign.isNotEmpty;
+  }
+}

--- a/at_commons/lib/src/verb/syntax.dart
+++ b/at_commons/lib/src/verb/syntax.dart
@@ -1,5 +1,7 @@
 class VerbSyntax {
-  static const from = r'^from:(?<atSign>@?[^@\s]+$)';
+  // Adding \{ and \} to regex to ensure the JSON encoded String is Map.
+  static const from =
+      r'^from:(?<atSign>@?[^@:\s]+)(:clientConfig:(?<clientConfig>\{.+\}))?$';
   static const pol = r'^pol$';
   static const cram = r'^cram:(?<digest>.+$)';
   static const pkam = r'^pkam:(?<signature>.+$)';
@@ -20,6 +22,7 @@ class VerbSyntax {
       r'^sync:from:(?<from_commit_seq>[0-9]+|-1)(:limit:(?<limit>\d+))(:(?<regex>.+))?$';
   static const update =
       r'^update:json:(?<json>.+)$|^update:(?:ttl:(?<ttl>\d+):)?(?:ttb:(?<ttb>\d+):)?(?:ttr:(?<ttr>(-?)\d+):)?(ccd:(?<ccd>true|false):)?(?:dataSignature:(?<dataSignature>[^:@]+):)?(?:sharedKeyStatus:(?<sharedKeyStatus>[^:@]+):)?(isBinary:(?<isBinary>true|false):)?(isEncrypted:(?<isEncrypted>true|false):)?(sharedKeyEnc:(?<sharedKeyEnc>[^:@]+):)?(pubKeyCS:(?<pubKeyCS>[^:@]+):)?(encoding:(?<encoding>\w+):)?(priority:(?<priority>low|medium|high):)?((?:public:)|(@(?<forAtSign>[^@:\s]*):))?(?<atKey>[^:@]((?!:{2})[^@])+)(?:@(?<atSign>[^@\s]*))? (?<value>.+$)';
+
   // ignore: constant_identifier_names
   static const update_meta =
       r'^update:meta:((?:public:)|((?<forAtSign>@?[^@\s]*):))?(?<atKey>((?!:{2})[^@])+)@(?<atSign>[^@:\s]*)(:ttl:(?<ttl>\d+))?(:ttb:(?<ttb>\d+))?(:ttr:(?<ttr>\d+))?(:ccd:(?<ccd>true|false))?(?:sharedKeyStatus:(?<sharedKeyStatus>[^:@]+):)?(:isBinary:(?<isBinary>true|false))?(:isEncrypted:(?<isEncrypted>true|false))?(sharedKeyEnc:(?<sharedKeyEnc>[^:@]+):)?(pubKeyCS:(?<pubKeyCS>[^:@]+))?$';

--- a/at_commons/test/from_verb_test.dart
+++ b/at_commons/test/from_verb_test.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_commons/src/verb/from_verb_builder.dart';
+import 'package:test/test.dart';
+
+import 'syntax_test.dart';
+
+void main() {
+  group('A group of positive tests to validate the from regex', () {
+    test('validating regex when atSign and client config are populated', () {
+      var command =
+          'from:@alice:$CLIENT_CONFIG:${jsonEncode({'version': '3.2.0'})}';
+      var actualVerbParams = getVerbParams(VerbSyntax.from, command);
+      expect(actualVerbParams['atSign'], '@alice');
+      expect(actualVerbParams[CLIENT_CONFIG], '{"version":"3.2.0"}');
+    });
+
+    test('validating regex when only atSign is populated', () {
+      var command = 'from:@alice';
+      var actualVerbParams = getVerbParams(VerbSyntax.from, command);
+      expect(actualVerbParams['atSign'], '@alice');
+    });
+  });
+
+  group('A group of negative tests to validated from regex', () {
+    test('A test to validate from verb builder with empty atSign', () {
+      var fromVerbBuilder = FromVerbBuilder()..atSign = '';
+      expect(fromVerbBuilder.checkParams(), false);
+      var command = fromVerbBuilder.buildCommand();
+      expect(
+          () => getVerbParams(VerbSyntax.from, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
+    });
+
+    test(
+        'validating regex when atSign is not populated and client config is populated',
+        () {
+      var fromVerbBuilder = FromVerbBuilder()
+        ..atSign = ''
+        ..clientConfig = {'version': '1.0.0'};
+      expect(fromVerbBuilder.checkParams(), false);
+      expect(fromVerbBuilder.clientConfig, {'version': '1.0.0'});
+      expect(fromVerbBuilder.clientConfig['version'], '1.0.0');
+      var command = fromVerbBuilder.buildCommand();
+      expect(
+          () => getVerbParams(VerbSyntax.from, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
+    });
+
+    test('A test to validate from verb builder with no atSign', () {
+      var fromVerbBuilder = FromVerbBuilder();
+      expect(() => fromVerbBuilder.buildCommand(),
+          throwsA(predicate((dynamic e) => e is Error)));
+    });
+  });
+
+  group('A group of from verb builder tests', () {
+    test('A test to validate from verb builder with only atSign', () {
+      var fromVerbBuilder = FromVerbBuilder()..atSign = '@alice';
+      expect(fromVerbBuilder.checkParams(), true);
+      expect(fromVerbBuilder.atSign, '@alice');
+      var command = fromVerbBuilder.buildCommand();
+      expect(command, 'from:@alice\n');
+    });
+
+    test('A test to validate from verb builder with atSign and client version',
+        () {
+      var fromVerbBuilder = FromVerbBuilder()
+        ..atSign = '@alice'
+        ..clientConfig = {'version': '1.0.0'};
+      expect(fromVerbBuilder.checkParams(), true);
+      expect(fromVerbBuilder.atSign, '@alice');
+      expect(fromVerbBuilder.clientConfig, {'version': '1.0.0'});
+      expect(fromVerbBuilder.clientConfig['version'], '1.0.0');
+      var command = fromVerbBuilder.buildCommand();
+      expect(command, 'from:@alice:clientConfig:{"version":"1.0.0"}\n');
+    });
+  });
+}

--- a/at_commons/test/syntax_test.dart
+++ b/at_commons/test/syntax_test.dart
@@ -41,14 +41,20 @@ void main() {
 
     test('id not sent to notify delete', () {
       var command = 'notify:remove:';
-      var verbParams = getVerbParams(VerbSyntax.notifyRemove, command);
-      expect(verbParams.isEmpty, true);
+      expect(
+              () => getVerbParams(VerbSyntax.notifyRemove, command),
+          throwsA(predicate((dynamic e) =>
+          e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
     });
   });
 }
 
 Map getVerbParams(String regex, String command) {
   var regExp = RegExp(regex, caseSensitive: false);
+  if (!regExp.hasMatch(command)) {
+    throw InvalidSyntaxException('command does not match the regex');
+  }
   var regexMatches = regExp.allMatches(command);
   var paramsMap = HashMap<String, String?>();
   for (var f in regexMatches) {

--- a/at_commons/test/update_verb_builder_test.dart
+++ b/at_commons/test/update_verb_builder_test.dart
@@ -1,4 +1,5 @@
 import 'package:at_commons/at_builders.dart';
+import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
 
 import 'syntax_test.dart';
@@ -117,8 +118,11 @@ void main() {
   group('A group of negative test on update verb regex', () {
     test('update verb with encoding value not specified', () {
       var command = 'update:encoding:@alice:phone@bob 123';
-      var actualVerbParams = getVerbParams(VerbSyntax.update, command);
-      expect(actualVerbParams.length, 0);
+      expect(
+          () => getVerbParams(VerbSyntax.update, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
     });
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Enhance from verb to accept the config configuration like version, supported features etc.
- clientConfig is hold a key-value pair which converted into JSON encoded string and sent to server. On Server side, decoded back to Map. Key's and corresponding value's are fetched.

**- How I did it**
- Modify from verb regex to hold Map instance as json encoded string.
- Introduce FromVerbBuilder to build from command.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->