### PR TITLE
feat: When validating AtKeys, allow namespace to be optional, for legacy app code which depends on keys without namespaces

### DIFF
--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -42,56 +42,58 @@ abstract class Regexes {
 
 class RegexesWithMandatoryNamespace implements Regexes {
   // There are currently no tests for this, but the regexes are and must remain mutually exclusive
-  @override
-  String get publicKey =>
-  '''${Regexes.publicKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _publicKey = '''${Regexes.publicKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _privateKey = '''${Regexes.privateKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _selfKey = '''${Regexes.selfKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _sharedKey = '''${Regexes.sharedKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _cachedSharedKey = '''${Regexes.cachedSharedKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  static const String _cachedPublicKey = '''${Regexes.cachedPublicKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
 
   @override
-  String get privateKey =>
-  '''${Regexes.privateKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  String get publicKey => _publicKey;
 
   @override
-  String get selfKey =>
-  '''${Regexes.selfKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  String get privateKey => _privateKey;
 
   @override
-  String get sharedKey =>
-  '''${Regexes.sharedKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  String get selfKey => _selfKey;
 
   @override
-  String get cachedSharedKey =>
-  '''${Regexes.cachedSharedKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  String get sharedKey => _sharedKey;
 
   @override
-  String get cachedPublicKey =>
-  '''${Regexes.cachedPublicKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+  String get cachedSharedKey => _cachedSharedKey;
+
+  @override
+  String get cachedPublicKey => _cachedPublicKey;
 }
 
 class RegexesNonMandatoryNamespace implements Regexes {
   // There are currently no tests for this, but the regexes are and must remain mutually exclusive
-  @override
-  String get publicKey =>
-      '''${Regexes.publicKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _publicKey = '''${Regexes.publicKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _privateKey = '''${Regexes.privateKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _selfKey = '''${Regexes.selfKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _sharedKey = '''${Regexes.sharedKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _cachedSharedKey = '''${Regexes.cachedSharedKeyStartFragment}${Regexes.ownershipFragment}''';
+  static const String _cachedPublicKey = '''${Regexes.cachedPublicKeyStartFragment}${Regexes.ownershipFragment}''';
 
   @override
-  String get privateKey =>
-      '''${Regexes.privateKeyStartFragment}${Regexes.ownershipFragment}''';
+  String get publicKey => _publicKey;
 
   @override
-  String get selfKey =>
-      '''${Regexes.selfKeyStartFragment}${Regexes.ownershipFragment}''';
+  String get privateKey => _privateKey;
 
   @override
-  String get sharedKey =>
-      '''${Regexes.sharedKeyStartFragment}${Regexes.ownershipFragment}''';
+  String get selfKey => _selfKey;
 
   @override
-  String get cachedSharedKey =>
-      '''${Regexes.cachedSharedKeyStartFragment}${Regexes.ownershipFragment}''';
+  String get sharedKey => _sharedKey;
 
   @override
-  String get cachedPublicKey =>
-      '''${Regexes.cachedPublicKeyStartFragment}${Regexes.ownershipFragment}''';
+  String get cachedSharedKey => _cachedSharedKey;
+
+  @override
+  String get cachedPublicKey => _cachedPublicKey;
 }
 
 class RegexUtil {

--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -2,43 +2,117 @@ import 'dart:collection';
 
 import 'package:at_commons/src/keystore/key_type.dart';
 
-class Regexes {
-  static const _charsInNamespace = r'([\w])+';
-  static const _charsInAtSign = r'[\w\-_]';
-  static const _charsInEntity = r'''[\w\.\-_'*"]''';
-  static const _allowedEmoji =
+abstract class Regexes {
+  static const charsInNamespace = r'([\w])+';
+  static const charsInAtSign = r'[\w\-_]';
+  static const charsInEntity = r'''[\w\.\-_'*"]''';
+  static const allowedEmoji =
       r'''((\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))''';
 
-  // Ideally these should be mutually exclusive, and they are. Will write tests for that.
-  static const publicKey =
-      '''(?<visibility>(public:){1})((@(?<sharedWith>($_charsInAtSign|$_allowedEmoji){1,55}):))?(?<entity>($_charsInEntity|$_allowedEmoji)+)\\.(?<namespace>$_charsInNamespace)@(?<owner>($_charsInAtSign|$_allowedEmoji){1,55})''';
-  static const privateKey =
-      '''(?<visibility>(private:){1})((@(?<sharedWith>($_charsInAtSign|$_allowedEmoji){1,55}):))?(?<entity>($_charsInEntity|$_allowedEmoji)+)\\.(?<namespace>$_charsInNamespace)@(?<owner>($_charsInAtSign|$_allowedEmoji){1,55})''';
-  static const selfKey =
-      '''((@(?<sharedWith>($_charsInAtSign|$_allowedEmoji){1,55}):))?(_*(?<entity>($_charsInEntity|$_allowedEmoji)+))\\.(?<namespace>$_charsInNamespace)@(?<owner>($_charsInAtSign|$_allowedEmoji){1,55})''';
-  static const sharedKey =
-      '''((@(?<sharedWith>($_charsInAtSign|$_allowedEmoji){1,55}):))(_*(?<entity>($_charsInEntity|$_allowedEmoji)+))\\.(?<namespace>$_charsInNamespace)@(?<owner>($_charsInAtSign|$_allowedEmoji){1,55})''';
-  static const cachedSharedKey =
-      '''((cached:)(@(?<sharedWith>($_charsInAtSign|$_allowedEmoji){1,55}):))(_*(?<entity>($_charsInEntity|$_allowedEmoji)+))\\.(?<namespace>$_charsInNamespace)@(?<owner>($_charsInAtSign|$_allowedEmoji){1,55})''';
-  static const cachedPublicKey =
-      '''(?<visibility>(cached:public:){1})((@(?<sharedWith>($_charsInAtSign|$_allowedEmoji){1,55}):))?(?<entity>($_charsInEntity|$_allowedEmoji)+)\\.(?<namespace>$_charsInNamespace)@(?<owner>($_charsInAtSign|$_allowedEmoji){1,55})''';
+  static const String namespaceFragment = '''\\.(?<namespace>$charsInNamespace)''';
+  static const String ownershipFragment = '''@(?<owner>($charsInAtSign|$allowedEmoji){1,55})''';
+  static const String sharedWithFragment = '''(?<sharedWith>($charsInAtSign|$allowedEmoji){1,55}):)''';
+  static const String entityFragment = '''(?<entity>($charsInEntity|$allowedEmoji)+)''';
+
+  static const String publicKeyStartFragment = '''(?<visibility>(public:){1})((@$sharedWithFragment)?$entityFragment''';
+  static const String privateKeyStartFragment = '''(?<visibility>(private:){1})((@$sharedWithFragment)?$entityFragment''';
+  static const String selfKeyStartFragment = '''((@$sharedWithFragment)?(_*$entityFragment)''';
+  static const String sharedKeyStartFragment = '''((@$sharedWithFragment)(_*$entityFragment)''';
+  static const String cachedSharedKeyStartFragment = '''((cached:)(@$sharedWithFragment)(_*$entityFragment)''';
+  static const String cachedPublicKeyStartFragment = '''(?<visibility>(cached:public:){1})((@$sharedWithFragment)?$entityFragment''';
+
+  String get publicKey;
+  String get privateKey;
+  String get selfKey;
+  String get sharedKey;
+  String get cachedSharedKey;
+  String get cachedPublicKey;
+
+  static final Regexes _regexesWithMandatoryNamespace = RegexesWithMandatoryNamespace();
+  static final Regexes _regexesNonMandatoryNamespace = RegexesNonMandatoryNamespace();
+
+  factory Regexes(bool enforceNamespace) {
+    if (enforceNamespace) {
+      return _regexesWithMandatoryNamespace;
+    } else {
+      return _regexesNonMandatoryNamespace;
+    }
+  }
+}
+
+class RegexesWithMandatoryNamespace implements Regexes {
+  // There are currently no tests for this, but the regexes are and must remain mutually exclusive
+  @override
+  String get publicKey =>
+  '''${Regexes.publicKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+
+  @override
+  String get privateKey =>
+  '''${Regexes.privateKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+
+  @override
+  String get selfKey =>
+  '''${Regexes.selfKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+
+  @override
+  String get sharedKey =>
+  '''${Regexes.sharedKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+
+  @override
+  String get cachedSharedKey =>
+  '''${Regexes.cachedSharedKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+
+  @override
+  String get cachedPublicKey =>
+  '''${Regexes.cachedPublicKeyStartFragment}${Regexes.namespaceFragment}${Regexes.ownershipFragment}''';
+}
+
+class RegexesNonMandatoryNamespace implements Regexes {
+  // There are currently no tests for this, but the regexes are and must remain mutually exclusive
+  @override
+  String get publicKey =>
+      '''${Regexes.publicKeyStartFragment}${Regexes.ownershipFragment}''';
+
+  @override
+  String get privateKey =>
+      '''${Regexes.privateKeyStartFragment}${Regexes.ownershipFragment}''';
+
+  @override
+  String get selfKey =>
+      '''${Regexes.selfKeyStartFragment}${Regexes.ownershipFragment}''';
+
+  @override
+  String get sharedKey =>
+      '''${Regexes.sharedKeyStartFragment}${Regexes.ownershipFragment}''';
+
+  @override
+  String get cachedSharedKey =>
+      '''${Regexes.cachedSharedKeyStartFragment}${Regexes.ownershipFragment}''';
+
+  @override
+  String get cachedPublicKey =>
+      '''${Regexes.cachedPublicKeyStartFragment}${Regexes.ownershipFragment}''';
 }
 
 class RegexUtil {
   /// Returns a first matching key type after matching the key against regexes for each of the key type
-  static KeyType keyType(String key) {
+  static KeyType keyType(String key, bool enforceNamespace) {
+    Regexes regexes = Regexes(enforceNamespace);
+    if (enforceNamespace) {
+
+    }
     // matches the key with public key regex.
-    if (matchAll(Regexes.publicKey, key)) {
+    if (matchAll(regexes.publicKey, key)) {
       return KeyType.publicKey;
     }
     // matches the key with private key regex.
-    if (matchAll(Regexes.privateKey, key)) {
+    if (matchAll(regexes.privateKey, key)) {
       return KeyType.privateKey;
     }
     // matches the key with self key regex.
-    if (matchAll(Regexes.selfKey, key)) {
+    if (matchAll(regexes.selfKey, key)) {
       Map<String, String> matches =
-          RegexUtil.matchesByGroup(Regexes.selfKey, key);
+          RegexUtil.matchesByGroup(regexes.selfKey, key);
       String? sharedWith = matches[RegexGroup.sharedWith.name()];
       // If owner is not specified set it to a empty string
       String? owner = matches[RegexGroup.owner.name()];
@@ -49,10 +123,10 @@ class RegexUtil {
       }
       return KeyType.selfKey;
     }
-    if (matchAll(Regexes.cachedPublicKey, key)) {
+    if (matchAll(regexes.cachedPublicKey, key)) {
       return KeyType.cachedPublicKey;
     }
-    if (matchAll(Regexes.cachedSharedKey, key)) {
+    if (matchAll(regexes.cachedSharedKey, key)) {
       return KeyType.cachedSharedKey;
     }
     return KeyType.invalidKey;

--- a/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -100,9 +100,7 @@ class RegexUtil {
   /// Returns a first matching key type after matching the key against regexes for each of the key type
   static KeyType keyType(String key, bool enforceNamespace) {
     Regexes regexes = Regexes(enforceNamespace);
-    if (enforceNamespace) {
 
-    }
     // matches the key with public key regex.
     if (matchAll(regexes.publicKey, key)) {
       return KeyType.publicKey;

--- a/at_commons/lib/src/validators/at_key_validation.dart
+++ b/at_commons/lib/src/validators/at_key_validation.dart
@@ -23,6 +23,9 @@ class ValidationContext {
 
   // validate the ownership of the key
   bool validateOwnership = true;
+
+  // enforce presence of namespace
+  bool enforceNamespace = false;
 }
 
 /// Represents outcome of a key validation

--- a/at_commons/lib/src/validators/at_key_validation_impl.dart
+++ b/at_commons/lib/src/validators/at_key_validation_impl.dart
@@ -50,38 +50,35 @@ class _AtKeyValidatorImpl extends AtKeyValidator {
     context.atSign = context.atSign?.replaceFirst('@', '');
     // If context.type is null, setType and regex.
     if (context.type == null) {
-      _setTypeAndRegex(key);
-      return;
+      _type = RegexUtil.keyType(key, context.enforceNamespace);
+    } else {
+      // if the type of the key is passed in the validation use that to init the regex
+      _type = context.type!;
     }
-    // if the type of the key is passed in the validation use that to init the regex
-    _type = context.type!;
-    _setRegex(context.type!);
+    _setRegex(_type, context.enforceNamespace);
   }
 
-  void _setTypeAndRegex(String key) {
-    _type = RegexUtil.keyType(key);
-    _setRegex(_type);
-  }
+  void _setRegex(KeyType type, bool enforceNamespace) {
+    Regexes regexes = Regexes(enforceNamespace);
 
-  void _setRegex(KeyType type) {
     switch (type) {
       case KeyType.publicKey:
-        _regex = Regexes.publicKey;
+        _regex = regexes.publicKey;
         break;
       case KeyType.privateKey:
-        _regex = Regexes.privateKey;
+        _regex = regexes.privateKey;
         break;
       case KeyType.selfKey:
-        _regex = Regexes.selfKey;
+        _regex = regexes.selfKey;
         break;
       case KeyType.sharedKey:
-        _regex = Regexes.sharedKey;
+        _regex = regexes.sharedKey;
         break;
       case KeyType.cachedPublicKey:
-        _regex = Regexes.cachedPublicKey;
+        _regex = regexes.cachedPublicKey;
         break;
       case KeyType.cachedSharedKey:
-        _regex = Regexes.cachedSharedKey;
+        _regex = regexes.cachedSharedKey;
         break;
       case KeyType.invalidKey:
         _regex = '';

--- a/at_commons/test/at_key_regex_test.dart
+++ b/at_commons/test/at_key_regex_test.dart
@@ -6,7 +6,7 @@ import 'test_keys.dart';
 
 void main() {
   group('A group of tests to validate keyType', () {
-    test('Tests to validate public key type', () {
+    test('Tests to validate public key type, namespace mandatory', () {
       var keyTypeList = [];
       keyTypeList.add('public:@bob:phone.buzz@bob');
       keyTypeList.add('public:phone.buzz@bob');
@@ -16,12 +16,38 @@ void main() {
       keyTypeList.add('public:phone.me@bob');
 
       for (var key in keyTypeList) {
-        var type = RegexUtil.keyType(key);
+        var type = RegexUtil.keyType(key, true);
         expect(type == KeyType.publicKey, true);
       }
     });
 
-    test('Tests to validate private key types', () {
+    test('Tests to validate public key type, namespace not mandatory', () {
+      var keyTypeList = [];
+      keyTypeList.add('public:@bob:phone.buzz@bob');
+      keyTypeList.add('public:@bob:phone@bob');
+
+      keyTypeList.add('public:phone.buzz@bob');
+      keyTypeList.add('public:phone@bob');
+
+      keyTypeList.add('public:@bob:p.b@bob');
+      keyTypeList.add('public:@bob:p@bob');
+
+      keyTypeList.add('public:pho_-ne.b@bob');
+      keyTypeList.add('public:pho_-ne@bob');
+
+      keyTypeList.add('public:@bob💙:phone😀.buzz@bob💙');
+      keyTypeList.add('public:@bob💙:phone😀@bob💙');
+
+      keyTypeList.add('public:phone.me@bob');
+      keyTypeList.add('public:phone@bob');
+
+      for (var key in keyTypeList) {
+        var type = RegexUtil.keyType(key, false);
+        expect(type == KeyType.publicKey, true);
+      }
+    });
+
+    test('Tests to validate private key types, namespace mandatory', () {
       var keyTypeList = [];
       keyTypeList.add("private:@bob:phone.buzz@bob");
       keyTypeList.add("private:phone.buzz@bob");
@@ -30,12 +56,35 @@ void main() {
       keyTypeList.add("private:@bob💙:phone😀.buzz@bob💙");
 
       for (var key in keyTypeList) {
-        var type = RegexUtil.keyType(key);
+        var type = RegexUtil.keyType(key, true);
         expect(type == KeyType.privateKey, true);
       }
     });
 
-    test('Tests to validate self key types', () {
+    test('Tests to validate private key types, namespace not mandatory', () {
+      var keyTypeList = [];
+      keyTypeList.add("private:@bob:phone.buzz@bob");
+      keyTypeList.add("private:@bob:phone@bob");
+
+      keyTypeList.add("private:phone.buzz@bob");
+      keyTypeList.add("private:phone@bob");
+
+      keyTypeList.add("private:@bob:p.b@bob");
+      keyTypeList.add("private:@bob:p@bob");
+
+      keyTypeList.add("private:pho_-ne.b@bob");
+      keyTypeList.add("private:pho_-ne@bob");
+
+      keyTypeList.add("private:@bob💙:phone😀.buzz@bob💙");
+      keyTypeList.add("private:@bob💙:phone😀@bob💙");
+
+      for (var key in keyTypeList) {
+        var type = RegexUtil.keyType(key, false);
+        expect(type == KeyType.privateKey, true);
+      }
+    });
+
+    test('Tests to validate self key types, namespace mandatory', () {
       var keyTypeList = [];
       keyTypeList.add("@bob:phone.buzz@bob");
       keyTypeList.add("phone.buzz@bob");
@@ -44,12 +93,35 @@ void main() {
       keyTypeList.add("@bob💙:phone😀.buzz@bob💙");
 
       for (var key in keyTypeList) {
-        var type = RegexUtil.keyType(key);
+        var type = RegexUtil.keyType(key, true);
         expect(type == KeyType.selfKey, true);
       }
     });
 
-    test('Tests to validate shared key types', () {
+    test('Tests to validate self key types, namespace not mandatory', () {
+      var keyTypeList = [];
+      keyTypeList.add("@bob:phone.buzz@bob");
+      keyTypeList.add("@bob:phone@bob");
+
+      keyTypeList.add("phone.buzz@bob");
+      keyTypeList.add("phone@bob");
+
+      keyTypeList.add("@bob:p.b@bob");
+      keyTypeList.add("@bob:p@bob");
+
+      keyTypeList.add("pho_-ne.b@bob");
+      keyTypeList.add("pho_-ne@bob");
+
+      keyTypeList.add("@bob💙:phone😀.buzz@bob💙");
+      keyTypeList.add("@bob💙:phone😀@bob💙");
+
+      for (var key in keyTypeList) {
+        var type = RegexUtil.keyType(key, false);
+        expect(type == KeyType.selfKey, true);
+      }
+    });
+
+    test('Tests to validate shared key types, namespace mandatory', () {
       var keyTypeList = [];
       keyTypeList.add("@alice:phone.buzz@bob");
       keyTypeList.add("@alice:phone.buzz@bob");
@@ -58,12 +130,35 @@ void main() {
       keyTypeList.add("@alice💙:phone😀.buzz@bob💙");
 
       for (var key in keyTypeList) {
-        var type = RegexUtil.keyType(key);
+        var type = RegexUtil.keyType(key, true);
         expect(type == KeyType.sharedKey, true);
       }
     });
 
-    test('Tests to validate cached public keys', () {
+    test('Tests to validate shared key types, namespace not mandatory', () {
+      var keyTypeList = [];
+      keyTypeList.add("@alice:phone.buzz@bob");
+      keyTypeList.add("@alice:phone@bob");
+
+      keyTypeList.add("@alice:phone.buzz@bob");
+      keyTypeList.add("@alice:phone@bob");
+
+      keyTypeList.add("@alice:p.b@bob");
+      keyTypeList.add("@alice:p@bob");
+
+      keyTypeList.add("@alice:pho_-ne.b@bob");
+      keyTypeList.add("@alice:pho_-ne@bob");
+
+      keyTypeList.add("@alice💙:phone😀.buzz@bob💙");
+      keyTypeList.add("@alice💙:phone😀@bob💙");
+
+      for (var key in keyTypeList) {
+        var type = RegexUtil.keyType(key, false);
+        expect(type == KeyType.sharedKey, true);
+      }
+    });
+
+    test('Tests to validate cached public keys, namespace mandatory', () {
       var keyTypeList = [];
       keyTypeList.add("cached:public:@jagannadh:phone.buzz@jagannadh");
       keyTypeList.add("cached:public:phone.buzz@jagannadh");
@@ -72,21 +167,63 @@ void main() {
       keyTypeList.add("cached:public:@jagannadh💙:phone😀.buzz@jagannadh💙");
 
       for (var key in keyTypeList) {
-        var type = RegexUtil.keyType(key);
+        var type = RegexUtil.keyType(key, true);
         expect(type == KeyType.cachedPublicKey, true);
       }
     });
 
-    test('Tests to validate cached shared keys', () {
+    test('Tests to validate cached public keys, namespace not mandatory', () {
       var keyTypeList = [];
-      keyTypeList.add(
-          "cached:@sitaram0123456789012345678901234567890123456789012345:phone.buzz@jagannadh");
+      keyTypeList.add("cached:public:@jagannadh:phone.buzz@jagannadh");
+      keyTypeList.add("cached:public:@jagannadh:phone@jagannadh");
+
+      keyTypeList.add("cached:public:phone.buzz@jagannadh");
+      keyTypeList.add("cached:public:phone@jagannadh");
+
+      keyTypeList.add("cached:public:p.b@jagannadh");
+      keyTypeList.add("cached:public:p@jagannadh");
+
+      keyTypeList.add("cached:public:pho_-n________e.b@jagannadh");
+      keyTypeList.add("cached:public:pho_-n________e@jagannadh");
+
+      keyTypeList.add("cached:public:@jagannadh💙:phone😀.buzz@jagannadh💙");
+      keyTypeList.add("cached:public:@jagannadh💙:phone😀@jagannadh💙");
+
+      for (var key in keyTypeList) {
+        var type = RegexUtil.keyType(key, false);
+        expect(type == KeyType.cachedPublicKey, true);
+      }
+    });
+
+    test('Tests to validate cached shared keys, namespace mandatory', () {
+      var keyTypeList = [];
+      keyTypeList.add("cached:@sitaram0123456789012345678901234567890123456789012345:phone.buzz@jagannadh");
       keyTypeList.add("cached:@sitaram:phone.buzz@jagannadh");
       keyTypeList.add("cached:@sitaram:pho_-n________e.b@jagannadh");
       keyTypeList.add("cached:@sitaram💙:phone😀.buzz@jagannadh💙");
 
       for (var key in keyTypeList) {
-        var type = RegexUtil.keyType(key);
+        var type = RegexUtil.keyType(key, true);
+        expect(type == KeyType.cachedSharedKey, true);
+      }
+    });
+
+    test('Tests to validate cached shared keys, namespace not mandatory', () {
+      var keyTypeList = [];
+      keyTypeList.add("cached:@sitaram0123456789012345678901234567890123456789012345:phone.buzz@jagannadh");
+      keyTypeList.add("cached:@sitaram0123456789012345678901234567890123456789012345:phone@jagannadh");
+
+      keyTypeList.add("cached:@sitaram:phone.buzz@jagannadh");
+      keyTypeList.add("cached:@sitaram:phone@jagannadh");
+
+      keyTypeList.add("cached:@sitaram:pho_-n________e.b@jagannadh");
+      keyTypeList.add("cached:@sitaram:pho_-n________e@jagannadh");
+
+      keyTypeList.add("cached:@sitaram💙:phone😀.buzz@jagannadh💙");
+      keyTypeList.add("cached:@sitaram💙:phone😀@jagannadh💙");
+
+      for (var key in keyTypeList) {
+        var type = RegexUtil.keyType(key, false);
         expect(type == KeyType.cachedSharedKey, true);
       }
     });
@@ -96,30 +233,42 @@ void main() {
     test('Valid public keys', () {
       var pubKeys = TestKeys().validPublicKeys;
       for (var i = 0; i < pubKeys.length; i++) {
-        expect(RegexUtil.matchAll(Regexes.publicKey, pubKeys[i]), true);
+        expect(RegexUtil.matchAll(Regexes(true).publicKey, pubKeys[i]), true);
+        expect(RegexUtil.matchAll(Regexes(false).publicKey, pubKeys[i]), true);
       }
     });
 
     test('Invalid public keys', () {
-      var invalidPubKeys = TestKeys().invalidPublicKeys;
+      List<String> invalidPubKeys;
+      invalidPubKeys = TestKeys().invalidPublicKeysNamespaceMandatory;
       for (var i = 0; i < invalidPubKeys.length; i++) {
-        expect(RegexUtil.matchAll(Regexes.publicKey, invalidPubKeys[i]), false);
+        expect(RegexUtil.matchAll(Regexes(true).publicKey, invalidPubKeys[i]), false);
+      }
+      invalidPubKeys = TestKeys().invalidPublicKeysNamespaceOptional;
+      for (var i = 0; i < invalidPubKeys.length; i++) {
+        expect(RegexUtil.matchAll(Regexes(false).publicKey, invalidPubKeys[i]), false);
       }
     });
 
     test('Valid private keys', () {
-      var privKeys = TestKeys().validPrivateKeys;
-      for (var i = 0; i < privKeys.length; i++) {
-        expect(RegexUtil.matchAll(Regexes.privateKey, privKeys[i]), true);
+      var privateKeys = TestKeys().validPrivateKeys;
+      for (var i = 0; i < privateKeys.length; i++) {
+        expect(RegexUtil.matchAll(Regexes(true).privateKey, privateKeys[i]), true);
+        expect(RegexUtil.matchAll(Regexes(false).privateKey, privateKeys[i]), true);
       }
     });
 
     test('Invalid private keys', () {
-      var invalidPrivKeys = TestKeys().invalidPrivateKeys;
-      for (var i = 0; i < invalidPrivKeys.length; i++) {
-        print(invalidPrivKeys[i]);
-        expect(
-            RegexUtil.matchAll(Regexes.privateKey, invalidPrivKeys[i]), false);
+      List<String> invalidPrivateKeys;
+      invalidPrivateKeys = TestKeys().invalidPrivateKeysNamespaceMandatory;
+      for (var i = 0; i < invalidPrivateKeys.length; i++) {
+        print(invalidPrivateKeys[i]);
+        expect(RegexUtil.matchAll(Regexes(true).privateKey, invalidPrivateKeys[i]), false);
+      }
+      invalidPrivateKeys = TestKeys().invalidPrivateKeysNamespaceOptional;
+      for (var i = 0; i < invalidPrivateKeys.length; i++) {
+        print(invalidPrivateKeys[i]);
+        expect(RegexUtil.matchAll(Regexes(false).privateKey, invalidPrivateKeys[i]), false);
       }
     });
   });
@@ -128,18 +277,20 @@ void main() {
     test('Valid cached public keys', () {
       var cachedPubKeys = TestKeys().validCachedPublicKeys;
       for (var i = 0; i < cachedPubKeys.length; i++) {
-        expect(RegexUtil.matchAll(Regexes.cachedPublicKey, cachedPubKeys[i]),
-            true);
+        expect(RegexUtil.matchAll(Regexes(true).cachedPublicKey, cachedPubKeys[i]), true);
+        expect(RegexUtil.matchAll(Regexes(false).cachedPublicKey, cachedPubKeys[i]), true);
       }
     });
 
     test('Invalid cached public keys', () {
-      var invalidCachedPubKeys = TestKeys().invalidCachedPublicKeys;
+      List<String> invalidCachedPubKeys;
+      invalidCachedPubKeys = TestKeys().invalidCachedPublicKeysNamespaceMandatory;
       for (var i = 0; i < invalidCachedPubKeys.length; i++) {
-        expect(
-            RegexUtil.matchAll(
-                Regexes.cachedPublicKey, invalidCachedPubKeys[i]),
-            false);
+        expect(RegexUtil.matchAll(Regexes(true).cachedPublicKey, invalidCachedPubKeys[i]), false);
+      }
+      invalidCachedPubKeys = TestKeys().invalidCachedPublicKeysNamespaceOptional;
+      for (var i = 0; i < invalidCachedPubKeys.length; i++) {
+        expect(RegexUtil.matchAll(Regexes(false).cachedPublicKey, invalidCachedPubKeys[i]), false);
       }
     });
   });
@@ -148,14 +299,20 @@ void main() {
     test('Valid Self keys', () {
       var validSelfKeys = TestKeys().validSelfKeys;
       for (var i = 0; i < validSelfKeys.length; i++) {
-        expect(RegexUtil.matchAll(Regexes.selfKey, validSelfKeys[i]), true);
+        expect(RegexUtil.matchAll(Regexes(true).selfKey, validSelfKeys[i]), true);
+        expect(RegexUtil.matchAll(Regexes(false).selfKey, validSelfKeys[i]), true);
       }
     });
 
     test('Invalid self keys', () {
-      var invalidSelfKeys = TestKeys().invalidSelfKeys;
+      List<String> invalidSelfKeys;
+      invalidSelfKeys = TestKeys().invalidSelfKeysNamespaceMandatory;
       for (var i = 0; i < invalidSelfKeys.length; i++) {
-        expect(RegexUtil.matchAll(Regexes.selfKey, invalidSelfKeys[i]), false);
+        expect(RegexUtil.matchAll(Regexes(true).selfKey, invalidSelfKeys[i]), false);
+      }
+      invalidSelfKeys = TestKeys().invalidSelfKeysNamespaceOptional;
+      for (var i = 0; i < invalidSelfKeys.length; i++) {
+        expect(RegexUtil.matchAll(Regexes(false).selfKey, invalidSelfKeys[i]), false);
       }
     });
 
@@ -163,16 +320,20 @@ void main() {
       test('Valid shared keys', () {
         var validSharedKeys = TestKeys().validSharedKeys;
         for (var i = 0; i < validSharedKeys.length; i++) {
-          expect(
-              RegexUtil.matchAll(Regexes.sharedKey, validSharedKeys[i]), true);
+          expect(RegexUtil.matchAll(Regexes(true).sharedKey, validSharedKeys[i]), true);
+          expect(RegexUtil.matchAll(Regexes(false).sharedKey, validSharedKeys[i]), true);
         }
       });
 
       test('Invalid shared keys', () {
-        var invalidSharedKeys = TestKeys().invalidSharedKeys;
+        List<String> invalidSharedKeys;
+        invalidSharedKeys = TestKeys().invalidSharedKeysNamespaceMandatory;
         for (var i = 0; i < invalidSharedKeys.length; i++) {
-          expect(RegexUtil.matchAll(Regexes.sharedKey, invalidSharedKeys[i]),
-              false);
+          expect(RegexUtil.matchAll(Regexes(true).sharedKey, invalidSharedKeys[i]), false);
+        }
+        invalidSharedKeys = TestKeys().invalidSharedKeysNamespaceOptional;
+        for (var i = 0; i < invalidSharedKeys.length; i++) {
+          expect(RegexUtil.matchAll(Regexes(false).sharedKey, invalidSharedKeys[i]), false);
         }
       });
 
@@ -180,20 +341,20 @@ void main() {
         var validCachedSharedKeys = TestKeys().validCachedSharedKeys;
         for (var i = 0; i < validCachedSharedKeys.length; i++) {
           print(validCachedSharedKeys[i]);
-          expect(
-              RegexUtil.matchAll(
-                  Regexes.cachedSharedKey, validCachedSharedKeys[i]),
-              true);
+          expect(RegexUtil.matchAll(Regexes(true).cachedSharedKey, validCachedSharedKeys[i]), true);
+          expect(RegexUtil.matchAll(Regexes(false).cachedSharedKey, validCachedSharedKeys[i]), true);
         }
       });
 
       test('Invalid cached shared keys', () {
-        var invalidCachedSharedKeys = TestKeys().invalidCachedSharedKeys;
+        List<String> invalidCachedSharedKeys;
+        invalidCachedSharedKeys = TestKeys().invalidCachedSharedKeysNamespaceMandatory;
         for (var i = 0; i < invalidCachedSharedKeys.length; i++) {
-          expect(
-              RegexUtil.matchAll(
-                  Regexes.cachedSharedKey, invalidCachedSharedKeys[i]),
-              false);
+          expect(RegexUtil.matchAll(Regexes(true).cachedSharedKey, invalidCachedSharedKeys[i]), false);
+        }
+        invalidCachedSharedKeys = TestKeys().invalidCachedSharedKeysNamespaceOptional;
+        for (var i = 0; i < invalidCachedSharedKeys.length; i++) {
+          expect(RegexUtil.matchAll(Regexes(false).cachedSharedKey, invalidCachedSharedKeys[i]), false);
         }
       });
     });

--- a/at_commons/test/test_keys.dart
+++ b/at_commons/test/test_keys.dart
@@ -1,16 +1,27 @@
 class TestKeys {
   List<String> validPublicKeys = [];
-  List<String> invalidPublicKeys = [];
+  List<String> invalidPublicKeysNamespaceMandatory = [];
+  List<String> invalidPublicKeysNamespaceOptional = [];
+
   List<String> validPrivateKeys = [];
-  List<String> invalidPrivateKeys = [];
+  List<String> invalidPrivateKeysNamespaceMandatory = [];
+  List<String> invalidPrivateKeysNamespaceOptional = [];
+
   List<String> validSharedKeys = [];
-  List<String> invalidSharedKeys = [];
+  List<String> invalidSharedKeysNamespaceMandatory = [];
+  List<String> invalidSharedKeysNamespaceOptional = [];
+
   List<String> validSelfKeys = [];
-  List<String> invalidSelfKeys = [];
+  List<String> invalidSelfKeysNamespaceMandatory = [];
+  List<String> invalidSelfKeysNamespaceOptional = [];
+
   List<String> validCachedPublicKeys = [];
-  List<String> invalidCachedPublicKeys = [];
+  List<String> invalidCachedPublicKeysNamespaceMandatory = [];
+  List<String> invalidCachedPublicKeysNamespaceOptional = [];
+
   List<String> validCachedSharedKeys = [];
-  List<String> invalidCachedSharedKeys = [];
+  List<String> invalidCachedSharedKeysNamespaceMandatory = [];
+  List<String> invalidCachedSharedKeysNamespaceOptional = [];
 
   TestKeys({bool includeNonBobKeys = true}) {
     _init(includeNonBobKeys);
@@ -57,12 +68,16 @@ class TestKeys {
     validPublicKeys.add("public:@bob💙:phone😀.buzz@bob💙");
 
     // More than 55 characters for the @sign
-    invalidPublicKeys.add(
+    List<String> temp = [];
+    temp.add(
         "public:@bob0123456789012345678901234567890123456789012345extrachars:phone.buzz@bob0123456789012345678901234567890123456789012345extrachars");
     //  Invalid punctuations in the @sign
-    invalidPublicKeys.add("public:@bo#b:phone.buzz@bo#b");
+    temp.add("public:@bo#b:phone.buzz@bo#b");
     //  Invalid and valid punctuations in the @sign
-    invalidPublicKeys.add("public:@jagan_____na#dh💙:phone.buzz@bob💙");
+    temp.add("public:@jagan_____na#dh💙:phone.buzz@bob💙");
+
+    invalidPublicKeysNamespaceMandatory.addAll(temp);
+    invalidPublicKeysNamespaceOptional.addAll(temp);
   }
 
   _initValidPublicKeys() {
@@ -87,22 +102,27 @@ class TestKeys {
   }
 
   _initInvalidPublicKeys() {
+    List<String> temp = [];
     // Misspelt public
-    invalidPublicKeys.add("publicc:@bob:phone.buzz@bob");
+    temp.add("publicc:@bob:phone.buzz@bob");
     //  No public
-    invalidPublicKeys.add("phone.buzz@bob");
-    //  No namespace
-    invalidPublicKeys.add("public:@bob:phone@bob");
+    temp.add("phone.buzz@bob");
     //  No public and start with a :
-    invalidPublicKeys.add(":phone.buzz@bob");
+    temp.add(":phone.buzz@bob");
     //  Invalid punctuations in the entity name
-    invalidPublicKeys.add("public:pho#ne.b@bob");
+    temp.add("public:pho#ne.b@bob");
     // Valid and invalid punctuations together
-    invalidPublicKeys.add("public:pho#n____-____e.b@bob");
+    temp.add("public:pho#n____-____e.b@bob");
     // Key with no atsign
-    invalidPublicKeys.add("public:pho#n____-____e.b");
+    temp.add("public:pho#n____-____e.b");
     // key without entity
-    invalidPublicKeys.add("public:@bob");
+    temp.add("public:@bob");
+
+    invalidPublicKeysNamespaceMandatory.addAll(temp);
+    invalidPublicKeysNamespaceOptional.addAll(temp);
+
+    //  No namespace
+    invalidPublicKeysNamespaceMandatory.add("public:@bob:phone@bob");
   }
 
   _initNonBobPrivateKeys() {
@@ -115,10 +135,15 @@ class TestKeys {
     validPrivateKeys.add("private:@bob💙:phone.buzz@bob💙");
     // 1Emoji in both @sign and entity
     validPrivateKeys.add("private:@bob💙:phone😀.buzz@bob💙");
+
+    List<String> temp = [];
     //  Invalid punctuations in the @sign
-    invalidPrivateKeys.add("private:@bo#b:phone.buzz@bo#b");
+    temp.add("private:@bo#b:phone.buzz@bo#b");
     //  Invalid and valid punctuations in the @sign
-    invalidPrivateKeys.add("private:@jagan_____na#dh💙:phone.buzz@bob💙");
+    temp.add("private:@jagan_____na#dh💙:phone.buzz@bob💙");
+
+    invalidPrivateKeysNamespaceMandatory.addAll(temp);
+    invalidPrivateKeysNamespaceOptional.addAll(temp);
   }
 
   _initValidPrivateKeys() {
@@ -139,21 +164,26 @@ class TestKeys {
   }
 
   _initInvalidPrivateKeys() {
+    List<String> temp = [];
     // Misspelt private
-    invalidPrivateKeys.add("privateeee:@bob:phone.buzz@bob");
+    temp.add("privateeee:@bob:phone.buzz@bob");
     //  No private
-    invalidPrivateKeys.add("phone.buzz@bob");
-    //  No namespace
-    invalidPrivateKeys.add("private:@bob:phone@bob");
+    temp.add("phone.buzz@bob");
     //  No private and start with a :
-    invalidPrivateKeys.add(":phone.buzz@bob");
+    temp.add(":phone.buzz@bob");
     //  Invalid punctuations in the entity name
-    invalidPrivateKeys.add("private:pho#ne.b@bob");
+    temp.add("private:pho#ne.b@bob");
     // Valid and invalid punctuations together
-    invalidPrivateKeys.add("private:pho#n____-____e.b@bob");
+    temp.add("private:pho#n____-____e.b@bob");
     // More than 55 characters for the @sign
-    invalidPrivateKeys.add(
+    temp.add(
         "private:@bob0123456789012345678901234567890123456789012345extracharshere:phone.buzz@bob");
+
+    invalidPrivateKeysNamespaceMandatory.addAll(temp);
+    invalidPrivateKeysNamespaceOptional.addAll(temp);
+
+    //  No namespace
+    invalidPrivateKeysNamespaceMandatory.add("private:@bob:phone@bob");
   }
 
   _initNonBobCachedPublicKeys() {
@@ -167,9 +197,12 @@ class TestKeys {
     validCachedPublicKeys.add("cached:public:@bob💙:phone.buzz@bob💙");
     // cached public public in both @sign and entity
     validCachedPublicKeys.add("cached:public:@bob💙:phone😀.buzz@bob💙");
+    List<String> temp = [];
     //  Invalid and valid punctuations in the @sign
-    invalidCachedPublicKeys
-        .add("cached:public:@jagan_____na#dh💙:phone.buzz@bob💙");
+    temp.add("cached:public:@jagan_____na#dh💙:phone.buzz@bob💙");
+
+    invalidCachedPublicKeysNamespaceMandatory.addAll(temp);
+    invalidCachedPublicKeysNamespaceOptional.addAll(temp);
   }
 
   _initValidCachedPublicKeys() {
@@ -190,23 +223,28 @@ class TestKeys {
   }
 
   _initInvalidCachedPublicKeys() {
+    List<String> temp = [];
     // Mis-spelt public
-    invalidCachedPublicKeys.add("cached:publicc:@bob:phone.buzz@bob");
+    temp.add("cached:publicc:@bob:phone.buzz@bob");
     //  No cached public
-    invalidCachedPublicKeys.add("phone.buzz@bob");
-    //  No namespace
-    invalidCachedPublicKeys.add("cached:public:@bob:phone@bob");
+    temp.add("phone.buzz@bob");
     //  No cached public and start with a :
-    invalidCachedPublicKeys.add(":phone.buzz@bob");
+    temp.add(":phone.buzz@bob");
     //  Invalid punctuations in the entity name
-    invalidCachedPublicKeys.add("cached:public:pho#ne.b@bob");
+    temp.add("cached:public:pho#ne.b@bob");
     // Valid and invalid punctuations together
-    invalidCachedPublicKeys.add("cached:public:pho#n____-____e.b@bob");
+    temp.add("cached:public:pho#n____-____e.b@bob");
     // More than 55 characters for the @sign
-    invalidCachedPublicKeys.add(
+    temp.add(
         "cached:public:@bob0123456789012345678901234567890123456789012345extracharshere:phone.buzz@bob");
     //  Invalid punctuations in the @sign
-    invalidCachedPublicKeys.add("cached:public:@jaganna#dh:phone.buzz@bob");
+    temp.add("cached:public:@jaganna#dh:phone.buzz@bob");
+
+    invalidCachedPublicKeysNamespaceMandatory.addAll(temp);
+    invalidCachedPublicKeysNamespaceOptional.addAll(temp);
+
+    //  No namespace
+    invalidCachedPublicKeysNamespaceMandatory.add("cached:public:@bob:phone@bob");
   }
 
   _initNonBobSelfKeys() {
@@ -219,8 +257,12 @@ class TestKeys {
     validSelfKeys.add("@bob💙:phone.buzz@bob💙");
     // 1Self key with emojis in both @sign and entity
     validSelfKeys.add("@bob💙:phone😀.buzz@bob💙");
+
+    List<String> temp = [];
     // Invalid and valid punctuations in the @sign
-    invalidSelfKeys.add("@jagan_____na#dh💙:phone.buzz@bob💙");
+    temp.add("@jagan_____na#dh💙:phone.buzz@bob💙");
+    invalidSelfKeysNamespaceMandatory.addAll(temp);
+    invalidSelfKeysNamespaceOptional.addAll(temp);
   }
 
   _initValidSelfKeys() {
@@ -241,19 +283,24 @@ class TestKeys {
   }
 
   _initInvalidSelfKeys() {
-    // No namespace
-    invalidSelfKeys.add("@bob:phone@bob");
+    List<String> temp = [];
     //  Starts with a :
-    invalidSelfKeys.add(":phone.buzz@bob");
+    temp.add(":phone.buzz@bob");
     //  Invalid punctuations in the entity name
-    invalidSelfKeys.add("@bob:pho#ne.b@bob");
+    temp.add("@bob:pho#ne.b@bob");
     //  Valid and invalid punctuations together
-    invalidSelfKeys.add("@bob:pho#n____-____e.b@bob");
+    temp.add("@bob:pho#n____-____e.b@bob");
     //  More than 55 characters for the @sign
-    invalidSelfKeys.add(
+    temp.add(
         "@bob0123456789012345678901234567890123456789012345extracharshere:phone.buzz@bob");
     // Invalid punctuations in the @sign
-    invalidSelfKeys.add("@jaganna#dh:phone.buzz@bob");
+    temp.add("@jaganna#dh:phone.buzz@bob");
+
+    invalidSelfKeysNamespaceMandatory.addAll(temp);
+    invalidSelfKeysNamespaceOptional.addAll(temp);
+
+    // No namespace
+    invalidSelfKeysNamespaceMandatory.add("@bob:phone@bob");
   }
 
   _initNonBobSharedKeys() {
@@ -266,8 +313,13 @@ class TestKeys {
     validSharedKeys.add("@alice💙:phone.buzz@bob💙");
     //  Shared key with emojis in both @sign and entity
     validSharedKeys.add("@alice💙:phone😀.buzz@bob💙");
+
+    List<String> temp = [];
     // Invalid and valid punctuations in the @sign
-    invalidSharedKeys.add("@sita_____ra#m💙:phone.buzz@bob💙");
+    temp.add("@sita_____ra#m💙:phone.buzz@bob💙");
+
+    invalidSharedKeysNamespaceMandatory.addAll(temp);
+    invalidSharedKeysNamespaceOptional.addAll(temp);
   }
 
   _initValidSharedKeys() {
@@ -286,19 +338,24 @@ class TestKeys {
   }
 
   _initInvalidSharedKeys() {
-    // No namespace
-    invalidSharedKeys.add("@alice:phone@bob");
+    List<String> temp = [];
     //  Starts with a :
-    invalidSharedKeys.add(":phone.buzz@bob");
+    temp.add(":phone.buzz@bob");
     //  Invalid punctuations in the entity name
-    invalidSharedKeys.add("@alice:pho#ne.b@bob");
+    temp.add("@alice:pho#ne.b@bob");
     //  Valid and invalid punctuations together
-    invalidSharedKeys.add("@alice:pho#n____-____e.b@bob");
+    temp.add("@alice:pho#n____-____e.b@bob");
     //  More than 55 characters for the @sign
-    invalidSharedKeys.add(
+    temp.add(
         "@alicemm0123456789012345678901234567890123456789012345extracharshere:phone.buzz@bob");
     // Invalid punctuations in the @sign
-    invalidSharedKeys.add("@sita#ram:phone.buzz@bob");
+    temp.add("@sita#ram:phone.buzz@bob");
+
+    invalidSharedKeysNamespaceMandatory.addAll(temp);
+    invalidSharedKeysNamespaceOptional.addAll(temp);
+
+    // No namespace
+    invalidSharedKeysNamespaceMandatory.add("@alice:phone@bob");
   }
 
   _initNonBobCachedSharedKeys() {
@@ -308,8 +365,13 @@ class TestKeys {
     validCachedSharedKeys.add("cached:@alice💙:phone.buzz@bob💙");
     //  Cached shared key with emojis in both @sign and entity
     validCachedSharedKeys.add("cached:@alice💙:phone😀.buzz@bob💙");
+
+    List<String> temp = [];
     // Invalid and valid punctuations in the @sign
-    invalidCachedSharedKeys.add("cached:@sita_____ra#m💙:phone.buzz@bob💙");
+    temp.add("cached:@sita_____ra#m💙:phone.buzz@bob💙");
+
+    invalidCachedSharedKeysNamespaceMandatory.addAll(temp);
+    invalidCachedSharedKeysNamespaceOptional.addAll(temp);
   }
 
   _initValidCachedSharedKeys() {
@@ -331,18 +393,23 @@ class TestKeys {
   }
 
   _initInvalidCachedSharedKeys() {
-    // No namespace
-    invalidCachedSharedKeys.add("cached:@alice:phone@bob");
+    List<String> temp = [];
     //  Starts with a :
-    invalidCachedSharedKeys.add(":phone.buzz@bob");
+    temp.add(":phone.buzz@bob");
     //  Invalid punctuations in the entity name
-    invalidCachedSharedKeys.add("cached:@alice:pho#ne.b@bob");
+    temp.add("cached:@alice:pho#ne.b@bob");
     //  Valid and invalid punctuations together
-    invalidCachedSharedKeys.add("cached:@alice:pho#n____-____e.b@bob");
+    temp.add("cached:@alice:pho#n____-____e.b@bob");
     //  More than 55 characters for the @sign
-    invalidCachedSharedKeys.add(
+    temp.add(
         "cached:@alicemm0123456789012345678901234567890123456789012345extracharshere:phone.buzz@bob");
     // Invalid punctuations in the @sign
-    invalidCachedSharedKeys.add("cached:@sita#ram:phone.buzz@bob");
+    temp.add("cached:@sita#ram:phone.buzz@bob");
+
+    invalidCachedSharedKeysNamespaceMandatory.addAll(temp);
+    invalidCachedSharedKeysNamespaceOptional.addAll(temp);
+
+    // No namespace
+    invalidCachedSharedKeysNamespaceMandatory.add("cached:@alice:phone@bob");
   }
 }


### PR DESCRIPTION
**- What I did**
feat: When validating AtKeys, allow namespace to be optional, for legacy app code which depends on keys without namespaces

resolves #220 

**- How I did it**
* Added new regexes to regex_utils to support namespace being optional. Refactored to eliminate resulting duplicate code.
* Adjusted regex_utils and at_key_validation_impl to detect type correctly and set the regex correctly, depending on whether namespace presence is to be enforced or not
* Added 'enforceNamespace' instance variable to ValidationContext. Defaults to false. Next version of AtClient will set enforceNamespace to true explicitly via AtClientPreferences, thus allowing apps to explicitly set it to false while they need it. At a later date, we will swtich the default value in ValidationContext to true rather than false.
* Added a whole load more tests to ensure we are testing with both the presence of namespace being enforced, and not being enforced.

**- How to verify it**
* Tests pass in this repo
* Tests pass in at_client_sdk for this PR https://github.com/atsign-foundation/at_client_sdk/pull/650 which uses this branch
* Tests pass in at_server for this PR https://github.com/atsign-foundation/at_server/pull/858 which uses this branch

**- Description for the changelog**
feat: When validating AtKeys, allow namespace to be optional, for legacy app code which depends on keys without namespaces
