### PR TITLE
fix: update meta and update regex change to handle negative values in ttl and ttb

### DIFF
--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.25
+* fix: update regex to correctly parse negative values in ttl and ttb
 ## 3.0.24
 * fix:  add error code for InvalidAtKeyException
 ## 3.0.23

--- a/at_commons/lib/src/verb/syntax.dart
+++ b/at_commons/lib/src/verb/syntax.dart
@@ -19,10 +19,10 @@ class VerbSyntax {
   static const syncFrom =
       r'^sync:from:(?<from_commit_seq>[0-9]+|-1)(:limit:(?<limit>\d+))(:(?<regex>.+))?$';
   static const update =
-      r'^update:json:(?<json>.+)$|^update:(?:ttl:(?<ttl>\d+):)?(?:ttb:(?<ttb>\d+):)?(?:ttr:(?<ttr>(-?)\d+):)?(ccd:(?<ccd>true|false):)?(?:dataSignature:(?<dataSignature>[^:@]+):)?(?:sharedKeyStatus:(?<sharedKeyStatus>[^:@]+):)?(isBinary:(?<isBinary>true|false):)?(isEncrypted:(?<isEncrypted>true|false):)?(sharedKeyEnc:(?<sharedKeyEnc>[^:@]+):)?(pubKeyCS:(?<pubKeyCS>[^:@]+):)?(encoding:(?<encoding>\w+):)?(priority:(?<priority>low|medium|high):)?((?:public:)|(@(?<forAtSign>[^@:\s]*):))?(?<atKey>[^:@]((?!:{2})[^@])+)(?:@(?<atSign>[^@\s]*))? (?<value>.+$)';
+      r'^update:json:(?<json>.+)$|^update:(?:ttl:(?<ttl>(-?)\d+):)?(?:ttb:(?<ttb>(-?)\d+):)?(?:ttr:(?<ttr>(-?)\d+):)?(ccd:(?<ccd>true|false):)?(?:dataSignature:(?<dataSignature>[^:@]+):)?(?:sharedKeyStatus:(?<sharedKeyStatus>[^:@]+):)?(isBinary:(?<isBinary>true|false):)?(isEncrypted:(?<isEncrypted>true|false):)?(sharedKeyEnc:(?<sharedKeyEnc>[^:@]+):)?(pubKeyCS:(?<pubKeyCS>[^:@]+):)?(encoding:(?<encoding>\w+):)?(priority:(?<priority>low|medium|high):)?((?:public:)|(@(?<forAtSign>[^@:\s]*):))?(?<atKey>[^:@]((?!:{2})[^@])+)(?:@(?<atSign>[^@\s]*))? (?<value>.+$)';
   // ignore: constant_identifier_names
   static const update_meta =
-      r'^update:meta:((?:public:)|((?<forAtSign>@?[^@\s]*):))?(?<atKey>((?!:{2})[^@])+)@(?<atSign>[^@:\s]*)(:ttl:(?<ttl>\d+))?(:ttb:(?<ttb>\d+))?(:ttr:(?<ttr>\d+))?(:ccd:(?<ccd>true|false))?(?:sharedKeyStatus:(?<sharedKeyStatus>[^:@]+):)?(:isBinary:(?<isBinary>true|false))?(:isEncrypted:(?<isEncrypted>true|false))?(sharedKeyEnc:(?<sharedKeyEnc>[^:@]+):)?(pubKeyCS:(?<pubKeyCS>[^:@]+))?$';
+      r'^update:meta:((?:public:)|((?<forAtSign>@?[^@\s]*):))?(?<atKey>((?!:{2})[^@])+)@(?<atSign>[^@:\s]*)(:ttl:(?<ttl>(-?)\d+))?(:ttb:(?<ttb>(-?)\d+))?(:ttr:(?<ttr>(-?)\d+))?(:ccd:(?<ccd>true|false))?(?:sharedKeyStatus:(?<sharedKeyStatus>[^:@]+):)?(:isBinary:(?<isBinary>true|false))?(:isEncrypted:(?<isEncrypted>true|false))?(sharedKeyEnc:(?<sharedKeyEnc>[^:@]+):)?(pubKeyCS:(?<pubKeyCS>[^:@]+))?$';
   static const delete =
       r'^delete:(priority:(?<priority>low|medium|high):)?(?:cached:)?((?:public:)|(@(?<forAtSign>[^@:\s]*):))?(?<atKey>[^:]((?!:{2})[^@])+)(@(?<atSign>[^@\s]+))?$';
   static const monitor = r'^monitor(:(?<epochMillis>\d+))?( (?<regex>.+))?$';

--- a/at_commons/pubspec.yaml
+++ b/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.24
+version: 3.0.25
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/at_commons/test/update_verb_builder_test.dart
+++ b/at_commons/test/update_verb_builder_test.dart
@@ -1,4 +1,5 @@
 import 'package:at_commons/at_builders.dart';
+import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
 
 import 'syntax_test.dart';
@@ -89,28 +90,68 @@ void main() {
   });
 
   group('A group of positive tests to validate the update regex', () {
-    var inputToExpectedOutput = {
-      'update:ttl:10000:ttb:10000:ttr:10000:ccd:true:dataSignature:123456:encoding:base64:public:phone@bob 12345':
-          {
-        'ttl': '10000',
-        'ttb': '10000',
-        'ttr': '10000',
-        'ccd': 'true',
-        'dataSignature': '123456',
-        'encoding': 'base64',
-        'forAtSign': null,
-        'atKey': 'phone',
-        'atSign': 'bob',
-        'value': '12345'
-      }
-    };
-    inputToExpectedOutput.forEach((command, expectedVerbParams) {
-      test('validating regex for $command', () {
-        var actualVerbParams = getVerbParams(VerbSyntax.update, command);
-        for (var key in expectedVerbParams.keys) {
-          expect(actualVerbParams[key], expectedVerbParams[key]);
+    test('validate update regex', () {
+      var inputToExpectedOutput = {
+        'update:ttl:10000:ttb:10000:ttr:10000:ccd:true:dataSignature:123456:encoding:base64:public:phone@bob 12345':
+            {
+          'ttl': '10000',
+          'ttb': '10000',
+          'ttr': '10000',
+          'ccd': 'true',
+          'dataSignature': '123456',
+          'encoding': 'base64',
+          'forAtSign': null,
+          'atKey': 'phone',
+          'atSign': 'bob',
+          'value': '12345'
         }
+      };
+      inputToExpectedOutput.forEach((command, expectedVerbParams) {
+        test('validating regex for $command', () {
+          var actualVerbParams = getVerbParams(VerbSyntax.update, command);
+          for (var key in expectedVerbParams.keys) {
+            expect(actualVerbParams[key], expectedVerbParams[key]);
+          }
+        });
       });
+    });
+    test('validate update command with negative ttl and ttr', () {
+      final updateCommand =
+          'update:ttl:-1:ttr:-1:dataSignature:abc:isBinary:false:isEncrypted:false:public:kryz.kryz_9850@kryz_9850 {"stationName":"KRYZ","frequency":"98.5 Mhz"}';
+      var actualVerbParams = getVerbParams(VerbSyntax.update, updateCommand);
+      expect(actualVerbParams[AT_TTL], '-1');
+      expect(actualVerbParams[AT_TTR], '-1');
+      expect(actualVerbParams[AT_KEY], 'kryz.kryz_9850');
+      expect(actualVerbParams[AT_SIGN], 'kryz_9850');
+    });
+    test('validate update command with negative ttl and ttb', () {
+      final updateCommand =
+          'update:ttl:-1:ttb:-1:dataSignature:abc:isBinary:false:isEncrypted:false:public:kryz.kryz_9850@kryz_9850 {"stationName":"KRYZ","frequency":"98.5 Mhz"}';
+      var actualVerbParams = getVerbParams(VerbSyntax.update, updateCommand);
+      expect(actualVerbParams[AT_TTL], '-1');
+      expect(actualVerbParams[AT_TTB], '-1');
+      expect(actualVerbParams[AT_KEY], 'kryz.kryz_9850');
+      expect(actualVerbParams[AT_SIGN], 'kryz_9850');
+    });
+    test('validate update meta command with negative ttl and ttr', () {
+      final updateCommand =
+          'update:meta:public:kryz.kryz_9850@kryz_9850:ttl:-1:ttr:-1';
+      var actualVerbParams =
+          getVerbParams(VerbSyntax.update_meta, updateCommand);
+      expect(actualVerbParams[AT_TTL], '-1');
+      expect(actualVerbParams[AT_TTR], '-1');
+      expect(actualVerbParams[AT_KEY], 'kryz.kryz_9850');
+      expect(actualVerbParams[AT_SIGN], 'kryz_9850');
+    });
+    test('validate update meta command with negative ttl and ttr', () {
+      final updateCommand =
+          'update:meta:public:kryz.kryz_9850@kryz_9850:ttl:-1:ttb:-1';
+      var actualVerbParams =
+          getVerbParams(VerbSyntax.update_meta, updateCommand);
+      expect(actualVerbParams[AT_TTL], '-1');
+      expect(actualVerbParams[AT_TTB], '-1');
+      expect(actualVerbParams[AT_KEY], 'kryz.kryz_9850');
+      expect(actualVerbParams[AT_SIGN], 'kryz_9850');
     });
   });
 

--- a/at_commons/test/update_verb_builder_test.dart
+++ b/at_commons/test/update_verb_builder_test.dart
@@ -90,29 +90,27 @@ void main() {
   });
 
   group('A group of positive tests to validate the update regex', () {
-    test('validate update regex', () {
-      var inputToExpectedOutput = {
-        'update:ttl:10000:ttb:10000:ttr:10000:ccd:true:dataSignature:123456:encoding:base64:public:phone@bob 12345':
-            {
-          'ttl': '10000',
-          'ttb': '10000',
-          'ttr': '10000',
-          'ccd': 'true',
-          'dataSignature': '123456',
-          'encoding': 'base64',
-          'forAtSign': null,
-          'atKey': 'phone',
-          'atSign': 'bob',
-          'value': '12345'
+    var inputToExpectedOutput = {
+      'update:ttl:10000:ttb:10000:ttr:10000:ccd:true:dataSignature:123456:encoding:base64:public:phone@bob 12345':
+          {
+        'ttl': '10000',
+        'ttb': '10000',
+        'ttr': '10000',
+        'ccd': 'true',
+        'dataSignature': '123456',
+        'encoding': 'base64',
+        'forAtSign': null,
+        'atKey': 'phone',
+        'atSign': 'bob',
+        'value': '12345'
+      }
+    };
+    inputToExpectedOutput.forEach((command, expectedVerbParams) {
+      test('validating regex for $command', () {
+        var actualVerbParams = getVerbParams(VerbSyntax.update, command);
+        for (var key in expectedVerbParams.keys) {
+          expect(actualVerbParams[key], expectedVerbParams[key]);
         }
-      };
-      inputToExpectedOutput.forEach((command, expectedVerbParams) {
-        test('validating regex for $command', () {
-          var actualVerbParams = getVerbParams(VerbSyntax.update, command);
-          for (var key in expectedVerbParams.keys) {
-            expect(actualVerbParams[key], expectedVerbParams[key]);
-          }
-        });
       });
     });
     test('validate update command with negative ttl and ttr', () {
@@ -143,7 +141,7 @@ void main() {
       expect(actualVerbParams[AT_KEY], 'kryz.kryz_9850');
       expect(actualVerbParams[AT_SIGN], 'kryz_9850');
     });
-    test('validate update meta command with negative ttl and ttr', () {
+    test('validate update meta command with negative ttl and ttb', () {
       final updateCommand =
           'update:meta:public:kryz.kryz_9850@kryz_9850:ttl:-1:ttb:-1';
       var actualVerbParams =


### PR DESCRIPTION
**- What I did**
- modified regex for update and update metadata command
**- How I did it**
- changed the regex to allow negative values in ttl and ttb so verb params will be correctly returned. Later on negative values will be rejected by server verb handler
**- How to verify it**
- run the unit tests in "A group of positive tests to validate the update regex"
