### PR TITLE
fix: Make ConsoleLoggingHandler singleton class

### DIFF
--- a/at_utils/lib/src/logging/atsignlogger.dart
+++ b/at_utils/lib/src/logging/atsignlogger.dart
@@ -9,9 +9,11 @@ class AtSignLogger {
   bool _hierarchicalLoggingEnabled = false;
   String? _level;
 
+  static var loggingHandler = ConsoleLoggingHandler();
+
   AtSignLogger(String name) {
     logger = logging.Logger.detached(name);
-    logger.onRecord.listen(ConsoleLoggingHandler());
+    logger.onRecord.listen(loggingHandler);
     level = _root_level;
   }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- The instances of ConsoleLoggingHandler are proportionate to the instances of AtSignLogger. Since ConsoleLoggingHandler is a state-less class, to optimise the memory usage, refactored to a singleton class.

**- How I did it**
- Add singleton nature to ConsoleLoggingHandler
- Add a static variable to hold ConsoleLoggingHandler in AtSignLogger.

**- How to verify it**
- The instances of ConsoleLoggingHandler should be only one. and logging mechanism should still work as earlier.

**- Description for the changelog**
- Optimise the memory usage.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->