### PR TITLE
fix: check size of chained exception list in getTraceMessage

### DIFF
--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.26
 * feat: Introduce notifyFetch verb
+* fix: bug in at_exception_stack.dart
 ## 3.0.25
 * fix: update regex to correctly parse negative values in ttl and ttb
 * feat: add clientConfig to from verb syntax

--- a/at_commons/lib/src/exception/at_exception_stack.dart
+++ b/at_commons/lib/src/exception/at_exception_stack.dart
@@ -17,8 +17,10 @@ class AtExceptionStack implements Comparable<AtChainedException> {
   String getTraceMessage() {
     var size = _exceptionList.length;
     String fullMessage = '';
-    fullMessage =
-        '${getIntentMessage(_exceptionList.first.intent)} caused by\n';
+    if (size > 0) {
+      fullMessage =
+          '${getIntentMessage(_exceptionList.first.intent)} caused by\n';
+    }
     for (AtChainedException element in _exceptionList) {
       size--;
       fullMessage += element.message;

--- a/at_commons/test/at_exception_stack_test.dart
+++ b/at_commons/test/at_exception_stack_test.dart
@@ -1,0 +1,32 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests for exception stack', () {
+    test('chained exception list size greater than zero - check trace message',
+        () {
+      final atChainedException = AtChainedException(
+          Intent.syncData, ExceptionScenario.invalidKeyFormed, 'sync issue');
+      final exceptionStack = AtExceptionStack();
+      exceptionStack.add(atChainedException);
+      expect(exceptionStack.getTraceMessage(), isNotEmpty);
+      expect(exceptionStack.getTraceMessage(),
+          startsWith('Failed to syncData caused by'));
+    });
+
+    test('chained exception list size is zero', () {
+      final exceptionStack = AtExceptionStack();
+      expect(exceptionStack.getTraceMessage(), isEmpty);
+    });
+
+    test('check intent message', () {
+      final atChainedException = AtChainedException(
+          Intent.syncData, ExceptionScenario.invalidKeyFormed, 'sync issue');
+      final exceptionStack = AtExceptionStack();
+      exceptionStack.add(atChainedException);
+      expect(exceptionStack.getIntentMessage(Intent.syncData), isNotEmpty);
+      expect(exceptionStack.getIntentMessage(Intent.syncData),
+          equals('Failed to syncData'));
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**
- fixed a bug in at_exception_stack.dart
**- How I did it**
- check the list size is greater than zero before fetching first element
**- How to verify it**
- run the unit test at_exception_stack_test.dart
