### PR TITLE
fix: issue getting config.yaml path

### DIFF
--- a/at_cli/lib/src/config_util.dart
+++ b/at_cli/lib/src/config_util.dart
@@ -1,11 +1,21 @@
+import 'dart:io';
+
 import 'package:at_utils/at_utils.dart';
 import 'package:yaml/yaml.dart';
+import 'package:path/path.dart' as path;
 
 class ConfigUtil {
   static final ApplicationConfiguration appConfig =
-      ApplicationConfiguration('config/config.yaml');
+      ApplicationConfiguration(_getConfigDirectory());
 
   static YamlMap? getYaml() {
     return appConfig.getYaml();
+  }
+
+  static String _getConfigDirectory() {
+    if (!File('config/config.yaml').existsSync()) {
+      return path.join(Directory.current.parent.path, 'config/config.yaml');
+    }
+    return path.join(Directory.current.path, 'config/config.yaml');
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When the main.dart is run from the project root directory, the program gets the config yaml from /config/config.yaml which works as expected. But when the same main.dart is run from inside the /bin directory the program still tries to get config yaml from /config/config.yaml which in this case does not exist. What I did is introduced a check to assert if the config file exists at the expected path; if the check fails the parent directory path is used.

**- How I did it**
Introduced a method that checks if /config/config.yaml exists from the present working directory. When the config file is not available from PWD, {parent_directory}/config/config.yaml is returned.

**- How to verify it**
Change directory into /bin and run main.dart with valid args, the program should execute without errors.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- fix: ensure that config.yaml can be reached when programs are executed from /bin