### PR TITLE
feat: Implement the `==` and `hashCode` methods for AtKey, AtValue and Metadata classes

### DIFF
--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.27
+* feat: Implement the `==` and `hashCode` methods for AtKey, AtValue and Metadata classes
 ## 3.0.26
 * feat: Introduce notifyFetch verb
 * fix: bug in at_exception_stack.dart

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -517,6 +517,55 @@ class Metadata {
     }
     return metaData;
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Metadata &&
+          runtimeType == other.runtimeType &&
+          ttl == other.ttl &&
+          ttb == other.ttb &&
+          ttr == other.ttr &&
+          ccd == other.ccd &&
+          availableAt == other.availableAt &&
+          expiresAt == other.expiresAt &&
+          refreshAt == other.refreshAt &&
+          createdAt == other.createdAt &&
+          updatedAt == other.updatedAt &&
+          dataSignature == other.dataSignature &&
+          sharedKeyStatus == other.sharedKeyStatus &&
+          isPublic == other.isPublic &&
+          isHidden == other.isHidden &&
+          namespaceAware == other.namespaceAware &&
+          isBinary == other.isBinary &&
+          isEncrypted == other.isEncrypted &&
+          isCached == other.isCached &&
+          sharedKeyEnc == other.sharedKeyEnc &&
+          pubKeyCS == other.pubKeyCS &&
+          encoding == other.encoding;
+
+  @override
+  int get hashCode =>
+      ttl.hashCode ^
+      ttb.hashCode ^
+      ttr.hashCode ^
+      ccd.hashCode ^
+      availableAt.hashCode ^
+      expiresAt.hashCode ^
+      refreshAt.hashCode ^
+      createdAt.hashCode ^
+      updatedAt.hashCode ^
+      dataSignature.hashCode ^
+      sharedKeyStatus.hashCode ^
+      isPublic.hashCode ^
+      isHidden.hashCode ^
+      namespaceAware.hashCode ^
+      isBinary.hashCode ^
+      isEncrypted.hashCode ^
+      isCached.hashCode ^
+      sharedKeyEnc.hashCode ^
+      pubKeyCS.hashCode ^
+      encoding.hashCode;
 }
 
 class AtValue {

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -10,6 +10,29 @@ class AtKey {
   Metadata? metadata;
   bool isRef = false;
 
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AtKey &&
+          runtimeType == other.runtimeType &&
+          key == other.key &&
+          _sharedWith == other._sharedWith &&
+          _sharedBy == other._sharedBy &&
+          namespace == other.namespace &&
+          metadata == other.metadata &&
+          isRef == other.isRef &&
+          _isLocal == other._isLocal;
+
+  @override
+  int get hashCode =>
+      key.hashCode ^
+      _sharedWith.hashCode ^
+      _sharedBy.hashCode ^
+      namespace.hashCode ^
+      metadata.hashCode ^
+      isRef.hashCode ^
+      _isLocal.hashCode;
+
   /// When set to true, represents the [LocalKey]
   /// These keys will never be synced between the client and secondary server.
   bool _isLocal = false;

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -576,4 +576,11 @@ class AtValue {
   String toString() {
     return 'AtValue{value: $value, metadata: $metadata}';
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is AtValue && runtimeType == other.runtimeType && value == other.value && metadata == other.metadata;
+
+  @override
+  int get hashCode => value.hashCode ^ metadata.hashCode;
 }

--- a/at_commons/pubspec.yaml
+++ b/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.26
+version: 3.0.27
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 


### PR DESCRIPTION
**- What I did**
* Implemented the `==` and `hashCode` methods for AtKey, AtValue and Metadata classes

**- Why I did it**
* Needed a way to assert that a List<AtKey> contains another AtKey. Simplest possible way of achieving that is to override the default `==` and `hashCode` methods for the AtKey and Metadata classes. As I was doing it for those two classes, I decided to do it for AtValue also.

**- How I did it**
* Added the IDE-generated implementations without modifiations

**- How to verify it**
* Tests pass in this repo, and in the at_client_sdk, at_server and at_libraries repos
* Will add links to PRs once they have had a successful GitHub actions run
  * at_client_sdk: https://github.com/atsign-foundation/at_client_sdk/pull/758
  * at_server: https://github.com/atsign-foundation/at_server/pull/980
* Initially those PRs will use a dependency override to point to this branch.
* Once this branch has been reviewed, merged to trunk and the new package published, I will modify the PRs in the other repos to remove their dependency override take up the new package version

**- Description for the changelog**
* feat: Implement the `==` and `hashCode` methods for AtKey, AtValue and Metadata classes
