### PR TITLE
fix: issue getting config.yaml path when main.dart is accessed globally

### DIFF
--- a/at_cli/bin/main.dart
+++ b/at_cli/bin/main.dart
@@ -8,6 +8,7 @@ import 'package:at_utils/at_logger.dart';
 
 void main(List<String> arguments) async {
   AtSignLogger.root_level = 'severe';
+  await ConfigUtil.init();
   var logger = AtSignLogger('AtCli');
   try {
     var parsedArgs = CommandLineParser.getParserResults(arguments);

--- a/at_cli/lib/src/config_util.dart
+++ b/at_cli/lib/src/config_util.dart
@@ -1,11 +1,29 @@
+import 'dart:io';
+import 'dart:isolate';
+
 import 'package:at_utils/at_utils.dart';
 import 'package:yaml/yaml.dart';
+import 'package:path/path.dart' as path;
 
 class ConfigUtil {
-  static final ApplicationConfiguration appConfig =
-      ApplicationConfiguration('config/config.yaml');
+  static late final ApplicationConfiguration appConfig;
 
+  static Future<void> init() async {
+      String configPath = await _getConfigFile();
+      appConfig = ApplicationConfiguration(configPath);
+  }
   static YamlMap? getYaml() {
     return appConfig.getYaml();
+  }
+
+  static Future<String> _getConfigFile() async {
+    var fileUri = await Isolate.resolvePackageUri(
+        Uri.parse('package:at_cli/'));
+    if (fileUri == null) {
+      throw Exception('Could not file config file at config/config.yaml');
+    }
+    Directory packageRoot = Directory.fromUri(fileUri).parent;
+    return path.join(packageRoot.path, 'config/config.yaml');
+
   }
 }

--- a/at_cli/lib/src/config_util.dart
+++ b/at_cli/lib/src/config_util.dart
@@ -21,7 +21,7 @@ class ConfigUtil {
     var fileUri = await Isolate.resolvePackageUri(
         Uri.parse('package:at_cli/'));
     if (fileUri == null) {
-      throw Exception('Could not file config file at config/config.yaml');
+      throw Exception('Could not find package location');
     }
     Directory packageRoot = Directory.fromUri(fileUri).parent;
     return path.join(packageRoot.path, 'config/config.yaml');


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Due to dart AOT compilation, the config file path cannot be asserted during runtime. This PR has changes to the methods that get the config Yaml that ensure that the config file path can be accessed during runtime.

**- How I did it**
- added a new method _getConfigFile() that gets the package path during runtime using "Isolate.resolvePackageUri"
- using the package root path to resolve the config.yaml file path
- the above methods need to be run asynchronously, for that introduced an init method in ConfigUtil class
- this init method is called from the bin/main.dart

**- How to verify it**
running the bin/main.dart file from any system path should work without throwing errors (provided all the valid args are declared)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- fix: ensure that config.yaml can be reached when programs are executed globally