### PR TITLE
fix: AtKey.fromString() defaults sharedWith to 'public'

### DIFF
--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.0.29
-* fix: AtKey.fromString() defaults sharedWith to 'public'
+* fix: AtKey.fromString() sets incorrect value in sharedWith attribute for public keys.
 ## 3.0.28
 * feat: Introduce the local key type
 ## 3.0.27

--- a/at_commons/CHANGELOG.md
+++ b/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.29
+* fix: AtKey.fromString() defaults sharedWith to 'public'
 ## 3.0.28
 * feat: Introduce the local key type
 ## 3.0.27

--- a/at_commons/lib/src/keystore/at_key.dart
+++ b/at_commons/lib/src/keystore/at_key.dart
@@ -242,7 +242,7 @@ class AtKey {
       if (keyParts[0] == 'public') {
         metaData.isPublic = true;
       }
-      if (keyParts[0] == 'local') {
+      else if (keyParts[0] == 'local') {
         atKey.isLocal = true;
       }
       // Example key: cached:@alice:phone@bob

--- a/at_commons/pubspec.yaml
+++ b/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.28
+version: 3.0.29
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/at_commons/test/at_key_test.dart
+++ b/at_commons/test/at_key_test.dart
@@ -27,6 +27,8 @@ void main() {
       expect(outKey.toString(), inKey.toString());
       expect(outKey.key, 'foo.bar');
       expect(outKey.namespace, 'attalk');
+      expect(outKey.metadata!.isPublic, false);
+      expect(outKey.isLocal, false);
     });
 
     test('Test to verify a public key', () {
@@ -35,6 +37,7 @@ void main() {
       expect(atKey.key, 'phone');
       expect(atKey.sharedBy, '@bob');
       expect(atKey.sharedWith, null);
+      expect(atKey.isLocal, false);
       expect(atKey.metadata!.isPublic, true);
       expect(atKey.metadata!.namespaceAware, false);
       expect(atKey.toString(), testKey);
@@ -46,6 +49,8 @@ void main() {
       expect(atKey.key, 'phone');
       expect(atKey.sharedBy, '@bob');
       expect(atKey.sharedWith, '@alice');
+      expect(atKey.metadata!.isPublic, false);
+      expect(atKey.isLocal, false);
       expect(atKey.toString(), testKey);
     });
 
@@ -54,6 +59,9 @@ void main() {
       var atKey = AtKey.fromString(testKey);
       expect(atKey.key, 'phone');
       expect(atKey.sharedBy, '@bob');
+      expect(atKey.sharedWith, null);
+      expect(atKey.metadata!.isPublic, false);
+      expect(atKey.isLocal, false);
       expect(atKey.toString(), testKey);
     });
 
@@ -65,6 +73,8 @@ void main() {
       expect(atKey.sharedWith, '@alice');
       expect(atKey.metadata!.isCached, true);
       expect(atKey.metadata!.namespaceAware, false);
+      expect(atKey.metadata!.isPublic, false);
+      expect(atKey.isLocal, false);
       expect(atKey.toString(), testKey);
     });
 
@@ -86,6 +96,8 @@ void main() {
       expect(atKey.key, 'phone');
       expect(atKey.sharedWith, '@alice');
       expect(atKey.sharedBy, '@bob');
+      expect(atKey.metadata!.isPublic, false);
+      expect(atKey.isLocal, false);
       expect(atKey.metadata!.namespaceAware, true);
       expect(atKey.toString(), testKey);
     });

--- a/at_commons/test/at_key_test.dart
+++ b/at_commons/test/at_key_test.dart
@@ -34,6 +34,7 @@ void main() {
       var atKey = AtKey.fromString(testKey);
       expect(atKey.key, 'phone');
       expect(atKey.sharedBy, '@bob');
+      expect(atKey.sharedWith, null);
       expect(atKey.metadata!.isPublic, true);
       expect(atKey.metadata!.namespaceAware, false);
       expect(atKey.toString(), testKey);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/apps/issues/739
**- What I did**
- ensured the exclusion of local and shared keys when the key was public
- made sure that sharedWIth parameter of the public key is set to null

**- How I did it**
- Changed the if-clause in AtKey.fromString() to else-if to enable proper exclusion

**- How to verify it**
- When creating a public AtKey using the fromString method, the sharedWith parameter is now null.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: AtKey.fromString() defaults sharedWith to 'public'