### PR TITLE
fix: enforce lowercase on AtKey

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.31
+* fix: enforce lowercase on all AtKey parameters
+* fix: set Metadata.isHidden true in PrivateKey class
 ## 3.0.30
 * fix: Add key validations to Update and llookup verb builders
 ## 3.0.29

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -100,6 +100,7 @@ class AtKey {
             (metadata!.isCached))) {
       return 'cached:public:$key${_dotNamespaceIfPresent()}$_sharedBy';
     }
+
     // If metadata.isPublic is true, return public key
     if (key!.startsWith('public:') ||
         (metadata != null &&
@@ -107,19 +108,27 @@ class AtKey {
             metadata!.isPublic!)) {
       return 'public:$key${_dotNamespaceIfPresent()}$_sharedBy';
     }
+
     //If metadata.isCached is true, return shared cached key
     if (key!.startsWith('cached:') ||
         (metadata != null && metadata!.isCached)) {
       return 'cached:$_sharedWith:$key${_dotNamespaceIfPresent()}$_sharedBy';
     }
+
     // If key starts with privatekey:, return private key
-    if (key!.startsWith('privatekey:')) {
-      return '$key';
+    if ((metadata != null && metadata!.isHidden) ||
+        key!.startsWith('privatekey:')) {
+      if (key!.startsWith('privatekey:')) {
+        return '$key'.toLowerCase();
+      }
+      return 'privatekey:$key${_dotNamespaceIfPresent()}'.toLowerCase();
     }
+
     //If _sharedWith is not null, return sharedKey
     if (_sharedWith != null && _sharedWith!.isNotEmpty) {
       return '$_sharedWith:$key${_dotNamespaceIfPresent()}$_sharedBy';
     }
+
     // if key starts with local: or isLocal set to true, return local key
     if (isLocal == true) {
       String localKey = '$key${_dotNamespaceIfPresent()}$sharedBy';
@@ -128,6 +137,7 @@ class AtKey {
       }
       return 'local:$localKey';
     }
+
     // Defaults to return a self key.
     return '$key${_dotNamespaceIfPresent()}$_sharedBy';
   }
@@ -358,7 +368,7 @@ class SharedKey extends AtKey {
 /// Represents a Private key.
 class PrivateKey extends AtKey {
   PrivateKey() {
-    super.metadata = Metadata();
+    super.metadata = Metadata()..isHidden = true;
   }
 
   @override

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -49,7 +49,8 @@ class AtKey {
 
   set sharedWith(String? sharedWithAtSign) {
     assertStartsWithAtIfNotEmpty(sharedWithAtSign);
-    if (sharedWithAtSign.isNotNullOrEmpty && (isLocal == true || metadata?.isPublic == true)) {
+    if (sharedWithAtSign.isNotNullOrEmpty &&
+        (isLocal == true || metadata?.isPublic == true)) {
       throw InvalidAtKeyException(
           'isLocal or isPublic cannot be true when sharedWith is set');
     }
@@ -294,6 +295,14 @@ class AtKey {
   /// Set enforceNamespace=true for strict namespace validation in the key.
   static KeyType getKeyType(String key, {bool enforceNameSpace = false}) {
     return RegexUtil.keyType(key, enforceNameSpace);
+  }
+
+  ///converts the AtKey to lowercase
+  void lowercase() {
+    key = key?.toLowerCase();
+    _sharedBy = _sharedBy?.toLowerCase();
+    _sharedWith = _sharedWith?.toLowerCase();
+    namespace = namespace?.toLowerCase();
   }
 }
 

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -41,10 +41,9 @@ class AtKey {
   String? get key => _key;
 
   set key(String? key) {
-    if (key.isNullOrEmpty) {
-      throw InvalidAtKeyException('Key cannot be null or empty');
+    if (key != null) {
+      _key = key.toLowerCase();
     }
-    _key = key?.toLowerCase();
   }
 
   String? get namespace => _namespace;

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -41,13 +41,18 @@ class AtKey {
   String? get key => _key;
 
   set key(String? key) {
+    if (key.isNullOrEmpty) {
+      throw InvalidAtKeyException('Key cannot be null or empty');
+    }
     _key = key?.toLowerCase();
   }
 
   String? get namespace => _namespace;
 
   set namespace(String? namespace) {
-    _namespace = namespace?.toLowerCase();
+    if (namespace != null && namespace.isNotEmpty) {
+      _namespace = namespace.toLowerCase();
+    }
   }
 
   String? get sharedBy => _sharedBy;

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -80,6 +80,7 @@ class AtKey {
     if (key.isNullOrEmpty) {
       throw InvalidAtKeyException('Key cannot be null or empty');
     }
+    enforceLowecase();
     // If metadata.isPublic is true and metadata.isCached is true,
     // return cached public key
     if (key!.startsWith('cached:public:') ||
@@ -229,11 +230,13 @@ class AtKey {
         key.startsWith(AT_PKAM_PUBLIC_KEY)) {
       atKey.key = key;
       atKey.metadata = metaData;
+      atKey.enforceLowecase();
       return atKey;
     } else if (key.startsWith(AT_ENCRYPTION_PRIVATE_KEY)) {
       atKey.key = key.split('@')[0];
       atKey._sharedBy = '@${key.split('@')[1]}';
       atKey.metadata = metaData;
+      atKey.enforceLowecase;
       return atKey;
     }
     //If key does not contain '@'. or key has space, it is not a valid key.
@@ -288,6 +291,7 @@ class AtKey {
       metaData.namespaceAware = false;
     }
     atKey.metadata = metaData;
+    atKey.enforceLowecase();
     return atKey;
   }
 
@@ -298,7 +302,7 @@ class AtKey {
   }
 
   ///converts the AtKey to lowercase
-  void lowercase() {
+  void enforceLowecase() {
     key = key?.toLowerCase();
     _sharedBy = _sharedBy?.toLowerCase();
     _sharedWith = _sharedWith?.toLowerCase();

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -80,7 +80,7 @@ class AtKey {
     if (key.isNullOrEmpty) {
       throw InvalidAtKeyException('Key cannot be null or empty');
     }
-    enforceLowecase();
+    enforceLowercase();
     // If metadata.isPublic is true and metadata.isCached is true,
     // return cached public key
     if (key!.startsWith('cached:public:') ||
@@ -230,13 +230,13 @@ class AtKey {
         key.startsWith(AT_PKAM_PUBLIC_KEY)) {
       atKey.key = key;
       atKey.metadata = metaData;
-      atKey.enforceLowecase();
+      atKey.enforceLowercase();
       return atKey;
     } else if (key.startsWith(AT_ENCRYPTION_PRIVATE_KEY)) {
       atKey.key = key.split('@')[0];
       atKey._sharedBy = '@${key.split('@')[1]}';
       atKey.metadata = metaData;
-      atKey.enforceLowecase;
+      atKey.enforceLowercase;
       return atKey;
     }
     //If key does not contain '@'. or key has space, it is not a valid key.
@@ -291,7 +291,7 @@ class AtKey {
       metaData.namespaceAware = false;
     }
     atKey.metadata = metaData;
-    atKey.enforceLowecase();
+    atKey.enforceLowercase();
     return atKey;
   }
 
@@ -302,7 +302,7 @@ class AtKey {
   }
 
   ///converts the AtKey to lowercase
-  void enforceLowecase() {
+  void enforceLowercase() {
     key = key?.toLowerCase();
     _sharedBy = _sharedBy?.toLowerCase();
     _sharedWith = _sharedWith?.toLowerCase();

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.30
+version: 3.0.31
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -106,8 +106,7 @@ void main() {
   group(
       'A group of positive test to construct a atKey with uppercase characters to assert their conversion to lowercase',
       () {
-    test('Assert key conversion to lowercase with AtKey.enforceLowercase()',
-        () {
+    test('Assert key conversion to lowercase', () {
       var fromAtsign = '@aliCe';
       var toAtsign = '@boB';
       var metaData = Metadata()..dataSignature = 'dfgDSFFkhkjh987686567464hbjh';
@@ -119,8 +118,7 @@ void main() {
         ..namespace = 'attAlk'
         ..metadata = metaData;
 
-      atKey.enforceLowercase();
-      //assert that all compnents of the AtKey are converted to lowercase
+      //assert that all components of the AtKey are converted to lowercase
       expect(atKey.key, 'foo.bar');
       expect(atKey.namespace, 'attalk');
       expect(atKey.sharedBy, '@alice');

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -103,6 +103,108 @@ void main() {
     });
   });
 
+  group(
+      'A group of positive test to construct a atKey with uppercase characters',
+      () {
+    test('toString and fromString with namespace', () {
+      var fromAtsign = '@aliCe';
+      var toAtsign = '@boB';
+      var metaData = Metadata()
+        ..isPublic = false
+        ..isEncrypted = true
+        ..namespaceAware = true
+        ..ttr = -1
+        ..ttl = 10000;
+
+      var inKey = AtKey()
+        ..key = 'foo.Bar'
+        ..sharedBy = fromAtsign
+        ..sharedWith = toAtsign
+        ..namespace = 'attAlk'
+        ..metadata = metaData;
+
+      expect(inKey.toString(), "@bob:foo.bar.attalk@alice");
+
+      var outKey = AtKey.fromString(inKey.toString());
+      expect(outKey.toString(), inKey.toString());
+      expect(outKey.key, 'foo.bar');
+      expect(outKey.namespace, 'attalk');
+      expect(outKey.metadata!.isPublic, false);
+      expect(outKey.isLocal, false);
+    });
+
+    test('Test to verify a public key', () {
+      var testKey = 'public:pHone@bOb';
+      var atKey = AtKey.fromString(testKey);
+      expect(atKey.key, 'phone');
+      expect(atKey.sharedBy, '@bob');
+      expect(atKey.sharedWith, null);
+      expect(atKey.isLocal, false);
+      expect(atKey.metadata!.isPublic, true);
+      expect(atKey.metadata!.namespaceAware, false);
+      expect(atKey.toString(), testKey.toLowerCase());
+    });
+
+    test('Test to verify protected key', () {
+      var testKey = '@aliCe:pHone@boB';
+      var atKey = AtKey.fromString(testKey);
+      expect(atKey.key, 'phone');
+      expect(atKey.sharedBy, '@bob');
+      expect(atKey.sharedWith, '@alice');
+      expect(atKey.metadata!.isPublic, false);
+      expect(atKey.isLocal, false);
+      expect(atKey.toString(), testKey.toLowerCase());
+    });
+
+    test('Test to verify private key', () {
+      var testKey = 'phoNe@bOb';
+      var atKey = AtKey.fromString(testKey);
+      expect(atKey.key, 'phone');
+      expect(atKey.sharedBy, '@bob');
+      expect(atKey.sharedWith, null);
+      expect(atKey.metadata!.isPublic, false);
+      expect(atKey.isLocal, false);
+      expect(atKey.toString(), testKey.toLowerCase());
+    });
+
+    test('Test to verify cached key', () {
+      var testKey = 'cached:@aliCe:pHone@Bob';
+      var atKey = AtKey.fromString(testKey);
+      expect(atKey.key, 'phone');
+      expect(atKey.sharedBy, '@bob');
+      expect(atKey.sharedWith, '@alice');
+      expect(atKey.metadata!.isCached, true);
+      expect(atKey.metadata!.namespaceAware, false);
+      expect(atKey.metadata!.isPublic, false);
+      expect(atKey.isLocal, false);
+      expect(atKey.toString(), testKey.toLowerCase());
+    });
+
+    test('Test to verify pkam private key', () {
+      var atKey = AtKey.fromString(AT_PKAM_PRIVATE_KEY);
+      expect(atKey.key, AT_PKAM_PRIVATE_KEY);
+      expect(atKey.toString(), AT_PKAM_PRIVATE_KEY);
+    });
+
+    test('Test to verify pkam private key', () {
+      var atKey = AtKey.fromString(AT_PKAM_PUBLIC_KEY);
+      expect(atKey.key, AT_PKAM_PUBLIC_KEY);
+      expect(atKey.toString(), AT_PKAM_PUBLIC_KEY);
+    });
+
+    test('Test to verify key with namespace', () {
+      var testKey = '@alice:phone.buzz@bob';
+      var atKey = AtKey.fromString(testKey);
+      expect(atKey.key, 'phone');
+      expect(atKey.sharedWith, '@alice');
+      expect(atKey.sharedBy, '@bob');
+      expect(atKey.metadata!.isPublic, false);
+      expect(atKey.isLocal, false);
+      expect(atKey.metadata!.namespaceAware, true);
+      expect(atKey.toString(), testKey);
+    });
+  });
+
   group('A group a negative test cases', () {
     test('Test to verify invalid syntax exception is thrown', () {
       var key = 'phone.buzz';

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -104,8 +104,30 @@ void main() {
   });
 
   group(
-      'A group of positive test to construct a atKey with uppercase characters',
+      'A group of positive test to construct a atKey with uppercase characters to assert their conversion to lowercase',
       () {
+    test('Assert key conversion to lowercase with AtKey.enforceLowercase()',
+        () {
+      var fromAtsign = '@aliCe';
+      var toAtsign = '@boB';
+      var metaData = Metadata()..dataSignature = 'dfgDSFFkhkjh987686567464hbjh';
+
+      AtKey atKey = AtKey()
+        ..key = 'foo.Bar'
+        ..sharedBy = fromAtsign
+        ..sharedWith = toAtsign
+        ..namespace = 'attAlk'
+        ..metadata = metaData;
+
+      atKey.enforceLowercase();
+      //assert that all compnents of the AtKey are converted to lowercase
+      expect(atKey.key, 'foo.bar');
+      expect(atKey.namespace, 'attalk');
+      expect(atKey.sharedBy, '@alice');
+      expect(atKey.sharedWith, '@bob');
+      //assert that dataSignature is not converted to lowercase
+      expect(atKey.metadata?.dataSignature, metaData.dataSignature);
+    });
     test('toString and fromString with namespace', () {
       var fromAtsign = '@aliCe';
       var toAtsign = '@boB';
@@ -223,8 +245,10 @@ void main() {
                   ..sharedBy = '@bob'
                   ..sharedWith = '@alice'
               },
-          throwsA(predicate(
-              (dynamic e) => e is InvalidAtKeyException && e.message == 'isLocal or isPublic cannot be true when sharedWith is set')));
+          throwsA(predicate((dynamic e) =>
+              e is InvalidAtKeyException &&
+              e.message ==
+                  'isLocal or isPublic cannot be true when sharedWith is set')));
     });
 
     test('Test cannot set sharedWith if isLocal is true', () {
@@ -235,8 +259,10 @@ void main() {
                   ..sharedBy = '@bob'
                   ..sharedWith = '@alice'
               },
-          throwsA(predicate(
-              (dynamic e) => e is InvalidAtKeyException && e.message == 'isLocal or isPublic cannot be true when sharedWith is set')));
+          throwsA(predicate((dynamic e) =>
+              e is InvalidAtKeyException &&
+              e.message ==
+                  'isLocal or isPublic cannot be true when sharedWith is set')));
     });
 
     test('Test cannot set isLocal to true if sharedWith is non-null', () {
@@ -247,8 +273,10 @@ void main() {
                   ..sharedWith = '@alice'
                   ..isLocal = true
               },
-          throwsA(predicate(
-              (dynamic e) => e is InvalidAtKeyException && e.message == 'sharedWith must be null when isLocal is set to true')));
+          throwsA(predicate((dynamic e) =>
+              e is InvalidAtKeyException &&
+              e.message ==
+                  'sharedWith must be null when isLocal is set to true')));
     });
   });
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- made key and namespace in AtKey class private variables and introduced getters and setters for the same
- enforcing toLowerCase() for all AtKey params in their respective setters
- set isHidden param of MetaData to true in PrivateKey class
- added isHidden check in AtKey.toString() to construct private keys when isHidden is set to true

**- How to verify it**
- test cases added to test/at_key_test.dart

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- chore: AtKey.key and AtKey.namespace made private(get and set introduced) and enforcing toLowerCase() for all AtKey params in their respective setters