### PR TITLE
fix: Move AtCompactionConfig to at_persistence_spec package

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.33
 - fix: enforce lowercase on all AtKey parameters
 - fix: set Metadata.isHidden true in PrivateKey class
+- fix: Deprecate AtCompactionConfig class
 ## 3.0.32
 - fix: Enable deletion of a local key
 ## 3.0.31

--- a/packages/at_commons/lib/at_commons.dart
+++ b/packages/at_commons/lib/at_commons.dart
@@ -6,7 +6,6 @@ export 'package:at_commons/src/at_constants.dart';
 export 'package:at_commons/src/at_message.dart';
 export 'package:at_commons/src/buffer/at_buffer.dart';
 export 'package:at_commons/src/buffer/at_buffer_impl.dart';
-export 'package:at_commons/src/compaction/at_compaction_config.dart';
 export 'package:at_commons/src/exception/at_client_exceptions.dart';
 export 'package:at_commons/src/exception/at_exception_manager.dart';
 export 'package:at_commons/src/exception/at_exception_stack.dart';

--- a/packages/at_commons/lib/src/compaction/at_compaction_config.dart
+++ b/packages/at_commons/lib/src/compaction/at_compaction_config.dart
@@ -1,3 +1,4 @@
+@Deprecated('Moved the class to at_persistence_spec package')
 class AtCompactionConfig {
   // -1 indicates storing for ever
   int sizeInKB = -1;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Deprecate the AtCompactionConfig class in at_commons

**- How I did it**
1. Add deprecate tag

**- Description for the changelog**
1. fix: Deprecate AtCompactionConfig class

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->