### PR TITLE
feat: New server-side exception ServerIsPausedException, error code AT0024

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.34
+- feat: New server-side exception ServerIsPausedException, error code AT0024
 ## 3.0.33
 - fix: Deprecate AtCompactionConfig class
 ## 3.0.32

--- a/packages/at_commons/lib/src/exception/at_server_exceptions.dart
+++ b/packages/at_commons/lib/src/exception/at_server_exceptions.dart
@@ -32,3 +32,8 @@ class InternalServerException extends AtServerException {
 class InternalServerError extends AtServerException {
   InternalServerError(message) : super(message);
 }
+
+/// Thrown when a request is received on a connection while the server is paused
+class ServerIsPausedException extends AtServerException {
+  ServerIsPausedException(message) : super(message);
+}

--- a/packages/at_commons/lib/src/exception/error_message.dart
+++ b/packages/at_commons/lib/src/exception/error_message.dart
@@ -19,7 +19,8 @@ const Map error_codes = {
   'InvalidAtKeyException': 'AT0016',
   'SecondaryConnectException': 'AT0021',
   'IllegalArgumentException': 'AT0022',
-  'AtTimeoutException': 'AT0023'
+  'AtTimeoutException': 'AT0023',
+  'ServerIsPausedException' : 'AT0024'
 };
 
 // ignore: constant_identifier_names
@@ -43,5 +44,6 @@ const Map error_description = {
   'AT0016': 'Invalid key',
   'AT0021': 'Unable to connect to secondary',
   'AT0022': 'Illegal arguments',
-  'AT0023': 'Timeout waiting for response'
+  'AT0023': 'Timeout waiting for response',
+  'AT0024': 'Server is paused'
 };

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.33
+version: 3.0.34
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 


### PR DESCRIPTION
**- What I did**
feat: New server-side exception ServerIsPausedException, error code AT0024

**- How I did it**
- Added new class ServerIsPausedException to at_server_exceptions.dart
- Added new error code AT0024 to error_description map in error_message.dart
- Added mapping from 'ServerIsPausedException' to 'AT0024' in error_codes map in error_message.dart

**- Description for the changelog**
feat: New server-side exception ServerIsPausedException, error code AT0024