### PR TITLE
fix: incorrect behaviour of cached:public keys in AtKey.fromString()

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.35
+- feat: enforce lowercase on AtKey(all key types included)
+- fix: incorrect behaviour of cached:public keys in AtKey.fromString()
 ## 3.0.34
 - feat: New server-side exception ServerIsPausedException, error code AT0024
 ## 3.0.33

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -272,11 +272,13 @@ class AtKey {
         metaData.isPublic = true;
       } else if (keyParts[0] == 'local') {
         atKey.isLocal = true;
-      }
-      // Example key: cached:@alice:phone@bob
-      else if (keyParts[0] == CACHED) {
+      } else if (keyParts[0] == CACHED) {
         metaData.isCached = true;
-        atKey.sharedWith = keyParts[1];
+        if(keyParts[1] == 'public'){
+          atKey.sharedWith = null; // Example key: cached:public:phone@bob
+        } else {
+          atKey.sharedWith = keyParts[1]; // Example key: cached:@alice:phone@bob
+        }
       } else {
         atKey.sharedWith = keyParts[0];
       }

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -275,6 +275,7 @@ class AtKey {
       } else if (keyParts[0] == CACHED) {
         metaData.isCached = true;
         if(keyParts[1] == 'public'){
+          metaData.isPublic = true;
           atKey.sharedWith = null; // Example key: cached:public:phone@bob
         } else {
           atKey.sharedWith = keyParts[1]; // Example key: cached:@alice:phone@bob

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -99,6 +99,7 @@ void main() {
       expect(atKey.sharedBy, '@demo');
       expect(atKey.key, 'test_key');
       expect(atKey.metadata!.isCached, true);
+      expect(atKey.metadata!.isPublic, true);
     });
 
     test('Test to verify cached:public key with namespace', (){
@@ -108,6 +109,7 @@ void main() {
       expect(atKey.sharedBy, '@demo');
       expect(atKey.key, 'test_key');
       expect(atKey.metadata!.isCached, true);
+      expect(atKey.metadata!.isPublic, true);
       expect(atKey.namespace, 'unit_test');
       expect(atKey.metadata!.namespaceAware, true);
     });

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -65,7 +65,7 @@ void main() {
       expect(atKey.toString(), testKey);
     });
 
-    test('Test to verify cached key', () {
+    test('Test to verify cached:shared key', () {
       var testKey = 'cached:@alice:phone@bob';
       var atKey = AtKey.fromString(testKey);
       expect(atKey.key, 'phone');
@@ -76,6 +76,40 @@ void main() {
       expect(atKey.metadata!.isPublic, false);
       expect(atKey.isLocal, false);
       expect(atKey.toString(), testKey);
+    });
+
+    test('Test to verify cached:shared key with namespace', () {
+      var testKey = 'cached:@alice:phone.unit_test@charlie';
+      var atKey = AtKey.fromString(testKey);
+      expect(atKey.key, 'phone');
+      expect(atKey.sharedBy, '@charlie');
+      expect(atKey.sharedWith, '@alice');
+      expect(atKey.metadata!.isCached, true);
+      expect(atKey.namespace, 'unit_test');
+      expect(atKey.metadata!.namespaceAware, true);
+      expect(atKey.metadata!.isPublic, false);
+      expect(atKey.isLocal, false);
+      expect(atKey.toString(), testKey);
+    });
+
+    test('Test to verify cached:public key', (){
+      var testKey = 'cached:public:test_key@demo';
+      var atKey = AtKey.fromString(testKey);
+      expect(atKey.sharedWith, null);
+      expect(atKey.sharedBy, '@demo');
+      expect(atKey.key, 'test_key');
+      expect(atKey.metadata!.isCached, true);
+    });
+
+    test('Test to verify cached:public key with namespace', (){
+      var testKey = 'cached:public:test_key.unit_test@demo';
+      var atKey = AtKey.fromString(testKey);
+      expect(atKey.sharedWith, null);
+      expect(atKey.sharedBy, '@demo');
+      expect(atKey.key, 'test_key');
+      expect(atKey.metadata!.isCached, true);
+      expect(atKey.namespace, 'unit_test');
+      expect(atKey.metadata!.namespaceAware, true);
     });
 
     test('Test to verify pkam private key', () {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_tools/issues/270
**- What I did**
- Corrected behaviour of AtKey.fromString() where cached: public keys were being treated as cached: sharedkeys.
Some more context: Due to this mishandling, fromString() was setting sharedWith atsign as '_public_' for cached:public keys when it should be set to null.
- Setting isPublic to true in metadata for cached:public keys

**- How I did it**
- added if-else clause to separate cached: public and cached:sharedkey behaviours

**- How to verify it**
- added test cases verifying the abovementioned changes

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: incorrect behaviour of cached:public keys in AtKey.fromString()