### PR TITLE
feat: Added new encryption metadata to the `notify` verb syntax

### DIFF
--- a/packages/at_commons/lib/src/at_constants.dart
+++ b/packages/at_commons/lib/src/at_constants.dart
@@ -5,6 +5,7 @@ const String AT_KEY = 'atKey';
 const String AT_VALUE = 'value';
 const String AT_DIGEST = 'digest';
 const String AT_PKAM_SIGNATURE = 'signature';
+const String PUBLIC_SCOPE_PARAM = 'publicScope';
 const String AT_PKAM_PRIVATE_KEY = 'privatekey:at_pkam_privatekey';
 const String AT_PKAM_PUBLIC_KEY = 'privatekey:at_pkam_publickey';
 const String AT_ENCRYPTION_PUBLIC_KEY = 'public:publickey';

--- a/packages/at_commons/lib/src/verb/abstract_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/abstract_verb_builder.dart
@@ -7,7 +7,7 @@ import 'package:at_commons/src/utils/string_utils.dart';
 /// the key (common for all verb builder) from the verb builder instances.
 abstract class AbstractVerbBuilder implements VerbBuilder {
   /// Represents the AtKey instance to populate the verb builder data
-  AtKey atKeyObj = AtKey();
+  AtKey atKeyObj = AtKey()..metadata=Metadata();
 
   /// Validates the [AtKey]
   ///

--- a/packages/at_commons/lib/src/verb/metadata_using_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/metadata_using_verb_builder.dart
@@ -1,0 +1,117 @@
+import 'package:meta/meta.dart';
+
+import '../keystore/at_key.dart';
+import 'abstract_verb_builder.dart';
+import 'verb_util.dart';
+
+abstract class MetadataUsingVerbBuilder extends AbstractVerbBuilder {
+  MetadataUsingVerbBuilder() {
+    atKeyObj.metadata!.isBinary = null;
+  }
+
+  /// See [AtKey.key]
+  String? get atKey => atKeyObj.key;
+  /// See [AtKey.key]
+  set atKey (String? s) => atKeyObj.key = s;
+
+  /// See [AtKey.sharedWith]
+  String? get sharedWith => atKeyObj.sharedWith;
+  /// See [AtKey.sharedWith]
+  set sharedWith (String? s) => atKeyObj.sharedWith = VerbUtil.formatAtSign(s);
+
+  /// See [AtKey.sharedBy]
+  String? get sharedBy => atKeyObj.sharedBy;
+  /// See [AtKey.sharedBy]
+  set sharedBy (String? s) => atKeyObj.sharedBy = VerbUtil.formatAtSign(s);
+
+  Metadata get metadata => atKeyObj.metadata!;
+
+  /// See [Metadata.isPublic]
+  bool get isPublic => metadata.isPublic!;
+  /// See [Metadata.isPublic]
+  set isPublic (bool b) => metadata.isPublic = b;
+
+  /// See [Metadata.isBinary]
+  bool? get isBinary => metadata.isBinary;
+  /// See [Metadata.isBinary]
+  set isBinary (bool? b) => metadata.isBinary = b;
+
+  /// See [Metadata.isEncrypted]
+  bool? get isEncrypted => metadata.isEncrypted;
+  /// See [Metadata.isEncrypted]
+  set isEncrypted (bool? b) => metadata.isEncrypted = b;
+  /// See [Metadata.isEncrypted]
+  bool? get isTextMessageEncrypted => metadata.isEncrypted;
+  /// See [Metadata.isEncrypted]
+  set isTextMessageEncrypted (bool? b) => metadata.isEncrypted = b;
+
+  /// See [Metadata.ttl]
+  int? get ttl => metadata.ttl;
+  /// See [Metadata.ttl]
+  set ttl (int? i) => metadata.ttl = i;
+
+  /// See [Metadata.ttb]
+  int? get ttb => metadata.ttb;
+  /// See [Metadata.ttb]
+  set ttb (int? i) => metadata.ttb = i;
+
+  /// See [Metadata.ttr]
+  int? get ttr => metadata.ttr;
+  /// See [Metadata.ttr]
+  set ttr (int? i) => metadata.ttr = i;
+
+  /// See [Metadata.ccd]
+  bool? get ccd => metadata.ccd;
+  /// See [Metadata.ccd]
+  set ccd (bool? b) => metadata.ccd = b;
+
+  /// See [Metadata.dataSignature]
+  String? get dataSignature => metadata.dataSignature;
+  /// See [Metadata.dataSignature]
+  set dataSignature (String? s) => metadata.dataSignature = s;
+
+  /// See [Metadata.sharedKeyStatus]
+  String? get sharedKeyStatus => metadata.sharedKeyStatus;
+  /// See [Metadata.sharedKeyStatus]
+  set sharedKeyStatus (String? s) => metadata.sharedKeyStatus = s;
+
+  /// See [Metadata.sharedKeyEnc]
+  String? get sharedKeyEncrypted => metadata.sharedKeyEnc;
+  /// See [Metadata.sharedKeyEnc]
+  set sharedKeyEncrypted (String? s) => metadata.sharedKeyEnc = s;
+
+  /// See [Metadata.pubKeyCS]
+  String? get pubKeyChecksum => metadata.pubKeyCS;
+  /// See [Metadata.pubKeyCS]
+  set pubKeyChecksum (String? s) => metadata.pubKeyCS = s;
+
+  /// See [Metadata.encoding]
+  String? get encoding => metadata.encoding;
+  /// See [Metadata.encoding]
+  set encoding (String? s) => metadata.encoding = s;
+
+  /// See [Metadata.encKeyName]
+  String? get encKeyName => metadata.encKeyName;
+  /// See [Metadata.encKeyName]
+  set encKeyName (String? s) => metadata.encKeyName = s;
+
+  /// See [Metadata.encAlgo]
+  String? get encAlgo => metadata.encAlgo;
+  /// See [Metadata.encAlgo]
+  set encAlgo (String? s) => metadata.encAlgo = s;
+
+  /// See [Metadata.ivNonce]
+  String? get ivNonce => metadata.ivNonce;
+  /// See [Metadata.ivNonce]
+  set ivNonce (String? s) => metadata.ivNonce = s;
+
+  /// See [Metadata.skeEncKeyName]
+  String? get skeEncKeyName => metadata.skeEncKeyName;
+  /// See [Metadata.skeEncKeyName]
+  set skeEncKeyName (String? s) => metadata.skeEncKeyName = s;
+
+  /// See [Metadata.skeEncAlgo]
+  String? get skeEncAlgo => metadata.skeEncAlgo;
+  /// See [Metadata.skeEncAlgo]
+  set skeEncAlgo (String? s) => metadata.skeEncAlgo = s;
+}

--- a/packages/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -1,39 +1,27 @@
-import 'package:at_commons/at_commons.dart';
+import 'package:at_commons/src/verb/abstract_verb_builder.dart';
 import 'package:at_commons/src/verb/verb_builder.dart';
+import 'package:meta/meta.dart';
 import 'package:uuid/uuid.dart';
 
-class NotifyVerbBuilder implements VerbBuilder {
+import '../at_constants.dart';
+import '../keystore/at_key.dart';
+import 'operation_enum.dart';
+import 'verb_util.dart';
+
+class NotifyVerbBuilder extends AbstractVerbBuilder implements VerbBuilder {
+  NotifyVerbBuilder() {
+    atKeyObj.metadata!.isBinary = null;
+  }
+
   /// id for each notification.
   String id = Uuid().v4();
-
-  /// Key that represents a user's information. e.g phone, location, email etc.,
-  String? atKey;
 
   /// Value of the key typically in string format. Images, files, etc.,
   /// must be converted to unicode string before storing.
   dynamic value;
 
-  /// AtSign to whom [atKey] has to be shared.
-  String? sharedWith;
-
-  /// AtSign of the client user calling this builder.
-  String? sharedBy;
-
-  /// if [isPublic] is true, then [atKey] is accessible by all atSigns.
-  /// if [isPublic] is false, then [atKey] is accessible either by [sharedWith] or [sharedBy]
-  bool isPublic = false;
-
-  /// time in milliseconds after which [atKey] expires.
-  int? ttl;
-
   /// time in milliseconds after which a notification expires.
   int? ttln;
-
-  /// time in milliseconds after which [atKey] becomes active.
-  int? ttb;
-
-  /// time in milliseconds to refresh [atKey].
-  int? ttr;
 
   OperationEnum? operation;
 
@@ -52,79 +40,157 @@ class NotifyVerbBuilder implements VerbBuilder {
   /// Latest N notifications to notify. Defaults to 1
   int? latestN;
 
-  bool? ccd;
+  /// See [AtKey.key]
+  String? get atKey => atKeyObj.key;
+  /// See [AtKey.key]
+  set atKey (String? s) => atKeyObj.key = s;
 
-  /// Represents if the [MessageTypeEnum.text] is encrypted or not. Setting to false to preserve
-  /// backward compatibility.
-  bool isTextMessageEncrypted = false;
+  /// See [AtKey.sharedWith]
+  String? get sharedWith => atKeyObj.sharedWith;
+  /// See [AtKey.sharedWith]
+  set sharedWith (String? s) => atKeyObj.sharedWith = VerbUtil.formatAtSign(s);
 
-  /// Will be set only when [sharedWith] is set. Will be encrypted using the public key of [sharedWith] atsign
-  String? sharedKeyEncrypted;
+  /// See [AtKey.sharedBy]
+  String? get sharedBy => atKeyObj.sharedBy;
+  /// See [AtKey.sharedBy]
+  set sharedBy (String? s) => atKeyObj.sharedBy = VerbUtil.formatAtSign(s);
 
-  /// checksum of the the public key of [sharedWith] atsign. Will be set only when [sharedWith] is set.
-  String? pubKeyChecksum;
+  @visibleForTesting
+  Metadata get metadata => atKeyObj.metadata!;
+
+  /// See [Metadata.isPublic]
+  bool get isPublic => metadata.isPublic!;
+  /// See [Metadata.isPublic]
+  set isPublic (bool b) => metadata.isPublic = b;
+
+  /// See [Metadata.isBinary]
+  bool? get isBinary => metadata.isBinary;
+  /// See [Metadata.isBinary]
+  set isBinary (bool? b) => metadata.isBinary = b;
+
+  /// See [Metadata.isEncrypted]
+  bool? get isEncrypted => metadata.isEncrypted;
+  /// See [Metadata.isEncrypted]
+  set isEncrypted (bool? b) => metadata.isEncrypted = b;
+  /// See [Metadata.isEncrypted]
+  bool? get isTextMessageEncrypted => metadata.isEncrypted;
+  /// See [Metadata.isEncrypted]
+  set isTextMessageEncrypted (bool? b) => metadata.isEncrypted = b;
+
+  /// See [Metadata.ttl]
+  int? get ttl => metadata.ttl;
+  /// See [Metadata.ttl]
+  set ttl (int? i) => metadata.ttl = i;
+
+  /// See [Metadata.ttb]
+  int? get ttb => metadata.ttb;
+  /// See [Metadata.ttb]
+  set ttb (int? i) => metadata.ttb = i;
+
+  /// See [Metadata.ttr]
+  int? get ttr => metadata.ttr;
+  /// See [Metadata.ttr]
+  set ttr (int? i) => metadata.ttr = i;
+
+  /// See [Metadata.ccd]
+  bool? get ccd => metadata.ccd;
+  /// See [Metadata.ccd]
+  set ccd (bool? b) => metadata.ccd = b;
+
+  /// See [Metadata.dataSignature]
+  String? get dataSignature => metadata.dataSignature;
+  /// See [Metadata.dataSignature]
+  set dataSignature (String? s) => metadata.dataSignature = s;
+
+  /// See [Metadata.sharedKeyStatus]
+  String? get sharedKeyStatus => metadata.sharedKeyStatus;
+  /// See [Metadata.sharedKeyStatus]
+  set sharedKeyStatus (String? s) => metadata.sharedKeyStatus = s;
+
+  /// See [Metadata.sharedKeyEnc]
+  String? get sharedKeyEncrypted => metadata.sharedKeyEnc;
+  /// See [Metadata.sharedKeyEnc]
+  set sharedKeyEncrypted (String? s) => metadata.sharedKeyEnc = s;
+
+  /// See [Metadata.pubKeyCS]
+  String? get pubKeyChecksum => metadata.pubKeyCS;
+  /// See [Metadata.pubKeyCS]
+  set pubKeyChecksum (String? s) => metadata.pubKeyCS = s;
+
+  /// See [Metadata.encoding]
+  String? get encoding => metadata.encoding;
+  /// See [Metadata.encoding]
+  set encoding (String? s) => metadata.encoding = s;
+
+  /// See [Metadata.encKeyName]
+  String? get encKeyName => metadata.encKeyName;
+  /// See [Metadata.encKeyName]
+  set encKeyName (String? s) => metadata.encKeyName = s;
+
+  /// See [Metadata.encAlgo]
+  String? get encAlgo => metadata.encAlgo;
+  /// See [Metadata.encAlgo]
+  set encAlgo (String? s) => metadata.encAlgo = s;
+
+  /// See [Metadata.ivNonce]
+  String? get ivNonce => metadata.ivNonce;
+  /// See [Metadata.ivNonce]
+  set ivNonce (String? s) => metadata.ivNonce = s;
+
+  /// See [Metadata.skeEncKeyName]
+  String? get skeEncKeyName => metadata.skeEncKeyName;
+  /// See [Metadata.skeEncKeyName]
+  set skeEncKeyName (String? s) => metadata.skeEncKeyName = s;
+
+  /// See [Metadata.skeEncAlgo]
+  String? get skeEncAlgo => metadata.skeEncAlgo;
+  /// See [Metadata.skeEncAlgo]
+  set skeEncAlgo (String? s) => metadata.skeEncAlgo = s;
 
   @override
   String buildCommand() {
-    var command = 'notify:id:$id:';
+    StringBuffer sb = StringBuffer();
+    sb.write('notify:id:$id');
 
     if (operation != null) {
-      command += '${getOperationName(operation)}:';
+      sb.write(':${getOperationName(operation)}');
     }
     if (messageType != null) {
-      command += 'messageType:${getMessageType(messageType)}:';
+      sb.write(':messageType:${getMessageType(messageType)}');
     }
     if (priority != null) {
-      command += 'priority:${getPriority(priority)}:';
+      sb.write(':priority:${getPriority(priority)}');
     }
     if (strategy != null) {
-      command += 'strategy:${getStrategy(strategy)}:';
+      sb.write(':strategy:${getStrategy(strategy)}');
     }
     if (latestN != null) {
-      command += 'latestN:$latestN:';
+      sb.write(':latestN:$latestN');
     }
-    command += 'notifier:$notifier:';
-    if (ttl != null) {
-      command += 'ttl:$ttl:';
-    }
-    if (ttln != null) {
-      command += 'ttln:$ttln:';
-    }
-    if (ttb != null) {
-      command += 'ttb:$ttb:';
-    }
-    if (ttr != null) {
-      ccd ??= false;
-      command += 'ttr:$ttr:ccd:$ccd:';
-    }
-    if (isTextMessageEncrypted) {
-      command += '$IS_ENCRYPTED:$isTextMessageEncrypted:';
-    }
+    sb.write(':notifier:$notifier');
 
-    if (sharedKeyEncrypted != null) {
-      command += '$SHARED_KEY_ENCRYPTED:$sharedKeyEncrypted:';
-    }
-    if (pubKeyChecksum != null) {
-      command += '$SHARED_WITH_PUBLIC_KEY_CHECK_SUM:$pubKeyChecksum:';
-    }
+    // Add in all of the metadata parameters in atProtocol command format
+    sb.write(metadata.toAtProtocolFragment());
 
     if (sharedWith != null) {
-      command += '${VerbUtil.formatAtSign(sharedWith)}:';
+      sb.write(':${VerbUtil.formatAtSign(sharedWith)}');
     }
 
     if (isPublic) {
-      command += 'public:';
+      sb.write(':public');
     }
-    command += atKey!;
+    sb.write(':${atKey!}');
 
     if (sharedBy != null) {
-      command += '${VerbUtil.formatAtSign(sharedBy)}';
+      sb.write('${VerbUtil.formatAtSign(sharedBy)}');
     }
     if (value != null) {
-      command += ':$value';
+      sb.write(':$value');
     }
 
-    return '$command\n';
+    sb.write('\n');
+
+    return sb.toString();
   }
 
   @override

--- a/packages/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -1,18 +1,11 @@
-import 'package:at_commons/src/verb/abstract_verb_builder.dart';
-import 'package:at_commons/src/verb/verb_builder.dart';
-import 'package:meta/meta.dart';
 import 'package:uuid/uuid.dart';
 
 import '../at_constants.dart';
-import '../keystore/at_key.dart';
+import 'metadata_using_verb_builder.dart';
 import 'operation_enum.dart';
 import 'verb_util.dart';
 
-class NotifyVerbBuilder extends AbstractVerbBuilder implements VerbBuilder {
-  NotifyVerbBuilder() {
-    atKeyObj.metadata!.isBinary = null;
-  }
-
+class NotifyVerbBuilder extends MetadataUsingVerbBuilder {
   /// id for each notification.
   String id = Uuid().v4();
 
@@ -39,113 +32,6 @@ class NotifyVerbBuilder extends AbstractVerbBuilder implements VerbBuilder {
 
   /// Latest N notifications to notify. Defaults to 1
   int? latestN;
-
-  /// See [AtKey.key]
-  String? get atKey => atKeyObj.key;
-  /// See [AtKey.key]
-  set atKey (String? s) => atKeyObj.key = s;
-
-  /// See [AtKey.sharedWith]
-  String? get sharedWith => atKeyObj.sharedWith;
-  /// See [AtKey.sharedWith]
-  set sharedWith (String? s) => atKeyObj.sharedWith = VerbUtil.formatAtSign(s);
-
-  /// See [AtKey.sharedBy]
-  String? get sharedBy => atKeyObj.sharedBy;
-  /// See [AtKey.sharedBy]
-  set sharedBy (String? s) => atKeyObj.sharedBy = VerbUtil.formatAtSign(s);
-
-  @visibleForTesting
-  Metadata get metadata => atKeyObj.metadata!;
-
-  /// See [Metadata.isPublic]
-  bool get isPublic => metadata.isPublic!;
-  /// See [Metadata.isPublic]
-  set isPublic (bool b) => metadata.isPublic = b;
-
-  /// See [Metadata.isBinary]
-  bool? get isBinary => metadata.isBinary;
-  /// See [Metadata.isBinary]
-  set isBinary (bool? b) => metadata.isBinary = b;
-
-  /// See [Metadata.isEncrypted]
-  bool? get isEncrypted => metadata.isEncrypted;
-  /// See [Metadata.isEncrypted]
-  set isEncrypted (bool? b) => metadata.isEncrypted = b;
-  /// See [Metadata.isEncrypted]
-  bool? get isTextMessageEncrypted => metadata.isEncrypted;
-  /// See [Metadata.isEncrypted]
-  set isTextMessageEncrypted (bool? b) => metadata.isEncrypted = b;
-
-  /// See [Metadata.ttl]
-  int? get ttl => metadata.ttl;
-  /// See [Metadata.ttl]
-  set ttl (int? i) => metadata.ttl = i;
-
-  /// See [Metadata.ttb]
-  int? get ttb => metadata.ttb;
-  /// See [Metadata.ttb]
-  set ttb (int? i) => metadata.ttb = i;
-
-  /// See [Metadata.ttr]
-  int? get ttr => metadata.ttr;
-  /// See [Metadata.ttr]
-  set ttr (int? i) => metadata.ttr = i;
-
-  /// See [Metadata.ccd]
-  bool? get ccd => metadata.ccd;
-  /// See [Metadata.ccd]
-  set ccd (bool? b) => metadata.ccd = b;
-
-  /// See [Metadata.dataSignature]
-  String? get dataSignature => metadata.dataSignature;
-  /// See [Metadata.dataSignature]
-  set dataSignature (String? s) => metadata.dataSignature = s;
-
-  /// See [Metadata.sharedKeyStatus]
-  String? get sharedKeyStatus => metadata.sharedKeyStatus;
-  /// See [Metadata.sharedKeyStatus]
-  set sharedKeyStatus (String? s) => metadata.sharedKeyStatus = s;
-
-  /// See [Metadata.sharedKeyEnc]
-  String? get sharedKeyEncrypted => metadata.sharedKeyEnc;
-  /// See [Metadata.sharedKeyEnc]
-  set sharedKeyEncrypted (String? s) => metadata.sharedKeyEnc = s;
-
-  /// See [Metadata.pubKeyCS]
-  String? get pubKeyChecksum => metadata.pubKeyCS;
-  /// See [Metadata.pubKeyCS]
-  set pubKeyChecksum (String? s) => metadata.pubKeyCS = s;
-
-  /// See [Metadata.encoding]
-  String? get encoding => metadata.encoding;
-  /// See [Metadata.encoding]
-  set encoding (String? s) => metadata.encoding = s;
-
-  /// See [Metadata.encKeyName]
-  String? get encKeyName => metadata.encKeyName;
-  /// See [Metadata.encKeyName]
-  set encKeyName (String? s) => metadata.encKeyName = s;
-
-  /// See [Metadata.encAlgo]
-  String? get encAlgo => metadata.encAlgo;
-  /// See [Metadata.encAlgo]
-  set encAlgo (String? s) => metadata.encAlgo = s;
-
-  /// See [Metadata.ivNonce]
-  String? get ivNonce => metadata.ivNonce;
-  /// See [Metadata.ivNonce]
-  set ivNonce (String? s) => metadata.ivNonce = s;
-
-  /// See [Metadata.skeEncKeyName]
-  String? get skeEncKeyName => metadata.skeEncKeyName;
-  /// See [Metadata.skeEncKeyName]
-  set skeEncKeyName (String? s) => metadata.skeEncKeyName = s;
-
-  /// See [Metadata.skeEncAlgo]
-  String? get skeEncAlgo => metadata.skeEncAlgo;
-  /// See [Metadata.skeEncAlgo]
-  set skeEncAlgo (String? s) => metadata.skeEncAlgo = s;
 
   @override
   String buildCommand() {

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -53,7 +53,7 @@ class VerbSyntax {
       r'^update'
       '$metadataFragment'
       r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
-      r':((?<atKey>[^:@\s]+)|(privatekey:at_pkam_publickey))'
+      r':(?<atKey>(([^:@\s]+)|(privatekey:at_pkam_publickey)))'
       r'(@(?<atSign>[^:@\s]+))?'
       r' (?<value>.+)'
       r'$';
@@ -71,7 +71,7 @@ class VerbSyntax {
       r'(:priority:(?<priority>low|medium|high))?'
       r'(:cached)?'
       r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
-      r':((?<atKey>[^:@\s]+)|(privatekey:at_secret))'
+      r':(?<atKey>(([^:@\s]+)|(privatekey:at_secret)))'
       r'(@(?<atSign>[^:@\s]+))?'
       r'$';
   static const monitor = r'^monitor(:(?<epochMillis>\d+))?( (?<regex>.+))?$';

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -29,7 +29,7 @@ class VerbSyntax {
       r'^sync:from:(?<from_commit_seq>[0-9]+|-1)(:limit:(?<limit>\d+))(:(?<regex>.+))?$';
 
   @visibleForTesting
-  static const metadata =
+  static const metadataFragment =
       r'(:ttl:(?<ttl>(-?)\d+))?'
       r'(:ttb:(?<ttb>(-?)\d+))?'
       r'(:ttr:(?<ttr>(-?)\d+))?'
@@ -51,36 +51,33 @@ class VerbSyntax {
       r'^update:json:(?<json>.+)$'
       r'|'
       r'^update'
-      '$metadata'
+      '$metadataFragment'
       r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
-      r':(?<atKey>[^:@]((?!:{2})[^:@\s])+)'
+      r':((?<atKey>[^:@\s]+)|(privatekey:at_pkam_publickey))'
       r'(@(?<atSign>[^:@\s]+))?'
       r' (?<value>.+)'
       r'$';
 
-  // NB: When adding metadata, you must add it to both the [update] and [update_meta] regexes,
-  // and the order must be the same.
   // ignore: constant_identifier_names
   static const update_meta =
       r'^update:meta'
       r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
       r':(?<atKey>[^:@]((?!:{2})[^:@])+)'
       r'@(?<atSign>[^:@\s]+)'
-      '$metadata'
+      '$metadataFragment'
       r'$';
   static const delete =
       r'^delete'
       r'(:priority:(?<priority>low|medium|high))?'
       r'(:cached)?'
       r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
-      r':(?<atKey>[^@:]((?!:{2})[^@:])+)'
+      r':((?<atKey>[^:@\s]+)|(privatekey:at_secret))'
       r'(@(?<atSign>[^:@\s]+))?'
       r'$';
   static const monitor = r'^monitor(:(?<epochMillis>\d+))?( (?<regex>.+))?$';
   static const stream =
       r'^stream:((?<operation>init|send|receive|done|resume))?((@(?<receiver>[^@:\s]+)))?( ?namespace:(?<namespace>[\w-]+))?( ?startByte:(?<startByte>\d+))?( (?<streamId>[\w-]*))?( (?<fileName>.* ))?((?<length>\d*))?$';
 
-  // notify:id:123:notifier:SYSTEM:public:email@alice:alice@gmail.com\n
   static const notify =
       r'^notify'
       r'(:id:(?<id>[\w\d\-\_]+))?'
@@ -91,7 +88,7 @@ class VerbSyntax {
       r'(:latestN:(?<latestN>\d+))?'
       r'(:notifier:(?<notifier>[^\s:]+))?'
       r'(:ttln:(?<ttln>\d+))?'
-      '$metadata'
+      '$metadataFragment'
       r':((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+)))'
       r':(?<atKey>[^:@]((?!:{2})[^@])+)'
       r'(@(?<atSign>[^:@\s]+))?'

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -1,32 +1,35 @@
+import 'package:meta/meta.dart';
+
 class VerbSyntax {
   // Adding \{ and \} to regex to ensure the JSON encoded String is Map.
   static const from =
-      r'^from:(?<atSign>@?[^@:\s]+)(:clientConfig:(?<clientConfig>\{.+\}))?$';
+      r'^from:(?<atSign>@?[^:@\s]+)(:clientConfig:(?<clientConfig>\{.+\}))?$';
   static const pol = r'^pol$';
   static const cram = r'^cram:(?<digest>.+$)';
   static const pkam = r'^pkam:(?<signature>.+$)';
   static const llookup =
-      r'^llookup:((?<operation>meta|all):)?(?:cached:)?((?:public:)|(@(?<forAtSign>[^@:\s]*):))?(?<atKey>[^:]((?!:{2})[^@])+)@(?<atSign>[^@\s]+)$';
+      r'^llookup'
+      r'(:(?<operation>meta|all))?'
+      r'(:cached)?'
+      r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
+      r':(?<atKey>[^:]((?!:{2})[^@])+)'
+      r'@(?<atSign>[^:@\s]+)$';
   static const plookup =
-      r'^plookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>[^@\s]+)@(?<atSign>[^@\s]+)$';
+      r'^plookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>[^@\s]+)@(?<atSign>[^:@\s]+)$';
   static const lookup =
-      r'^lookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>(?:[^:]).+)@(?<atSign>[^@\s]+)$';
+      r'^lookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>(?:[^:]).+)@(?<atSign>[^:@\s]+)$';
   static const scan =
       r'^scan$|scan(:showhidden:(?<showhidden>true|false))?(:(?<forAtSign>@[^:@\s]+))?(:page:(?<page>\d+))?( (?<regex>\S+))?$';
   static const config =
-      r'^config:(?:(?<=config:)block:(?<operation>add|remove|show)(?:(?<=show)\s?$|(?:(?<=add|remove):(?<atSign>(?:@[^\s@]+)( (?:@[^\s@]+))*$))))|(?:(?<=config:)(?<setOperation>set|reset|print):(?<configNew>.+)$)';
+      r'^config:(?:(?<=config:)block:(?<operation>add|remove|show)(?:(?<=show)\s?$|(?:(?<=add|remove):(?<atSign>(?:@[^:@\s]+)( (?:@[^\s@]+))*$))))|(?:(?<=config:)(?<setOperation>set|reset|print):(?<configNew>.+)$)';
   static const stats =
       r'^stats(?<statId>:((?!0)\d+)?(,(\d+))*)?(:(?<regex>(?<=:3:).+))?$';
   static const sync = r'^sync:(?<from_commit_seq>[0-9]+|-1)(:(?<regex>.+))?$';
   static const syncFrom =
       r'^sync:from:(?<from_commit_seq>[0-9]+|-1)(:limit:(?<limit>\d+))(:(?<regex>.+))?$';
 
-  // NB: When adding metadata, you must add it to both the [update] and [update_meta] regexes,
-  // and the order must be the same.
-  static const update =
-      r'^update:json:(?<json>.+)$'
-      r'|'
-      r'^update'
+  @visibleForTesting
+  static const metadata =
       r'(:ttl:(?<ttl>(-?)\d+))?'
       r'(:ttb:(?<ttb>(-?)\d+))?'
       r'(:ttr:(?<ttr>(-?)\d+))?'
@@ -38,51 +41,76 @@ class VerbSyntax {
       r'(:sharedKeyEnc:(?<sharedKeyEnc>[^:@\s]+))?'
       r'(:pubKeyCS:(?<pubKeyCS>[^:@\s]+))?'
       r'(:encoding:(?<encoding>[^:@\s]+))?'
-      r'(:priority:(?<priority>low|medium|high))?'
       r'(:encKeyName:(?<encKeyName>[^:@\s]+))?'
       r'(:encAlgo:(?<encAlgo>[^:@\s]+))?'
       r'(:ivNonce:(?<ivNonce>[^:@\s]+))?'
       r'(:skeEncKeyName:(?<skeEncKeyName>[^:@\s]+))?'
-      r'(:skeEncAlgo:(?<skeEncAlgo>[^:@\s]+))?'
-      r':((public:)|(@(?<forAtSign>[^@:\s]*):))?(?<atKey>[^:@]((?!:{2})[^@])+)(@(?<atSign>[^@:\s]*))? (?<value>.+$)';
+      r'(:skeEncAlgo:(?<skeEncAlgo>[^:@\s]+))?';
+
+  static const update =
+      r'^update:json:(?<json>.+)$'
+      r'|'
+      r'^update'
+      '$metadata'
+      r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
+      r':(?<atKey>[^:@]((?!:{2})[^:@\s])+)'
+      r'(@(?<atSign>[^:@\s]+))?'
+      r' (?<value>.+)'
+      r'$';
 
   // NB: When adding metadata, you must add it to both the [update] and [update_meta] regexes,
   // and the order must be the same.
   // ignore: constant_identifier_names
   static const update_meta =
-      r'^update:meta:((public:)|(@(?<forAtSign>[^@:\s]*):))?'
-      r'(?<atKey>[^:@]((?!:{2})[^@])+)@(?<atSign>[^@:\s]*)'
-      r'(:ttl:(?<ttl>(-?)\d+))?'
-      r'(:ttb:(?<ttb>(-?)\d+))?'
-      r'(:ttr:(?<ttr>(-?)\d+))?'
-      r'(:ccd:(?<ccd>true|false))?'
-      r'(:dataSignature:(?<dataSignature>[^:@\s]+))?'
-      r'(:sharedKeyStatus:(?<sharedKeyStatus>[^:@\s]+))?'
-      r'(:isBinary:(?<isBinary>true|false))?'
-      r'(:isEncrypted:(?<isEncrypted>true|false))?'
-      r'(:sharedKeyEnc:(?<sharedKeyEnc>[^:@\s]+))?'
-      r'(:pubKeyCS:(?<pubKeyCS>[^:@\s]+))?'
-      r'(:encoding:(?<encoding>[^:@\s]+))?'
-      r'(:priority:(?<priority>low|medium|high))?'
-      r'(:encKeyName:(?<encKeyName>[^:@\s]+))?'
-      r'(:encAlgo:(?<encAlgo>[^:@\s]+))?'
-      r'(:ivNonce:(?<ivNonce>[^:@\s]+))?'
-      r'(:skeEncKeyName:(?<skeEncKeyName>[^:@\s]+))?'
-      r'(:skeEncAlgo:(?<skeEncAlgo>[^:@\s]+))?'
+      r'^update:meta'
+      r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
+      r':(?<atKey>[^:@]((?!:{2})[^:@])+)'
+      r'@(?<atSign>[^:@\s]+)'
+      '$metadata'
       r'$';
   static const delete =
-      r'^delete:(priority:(?<priority>low|medium|high):)?(?:cached:)?((?:public:)|(@(?<forAtSign>[^@:\s]*):))?(?<atKey>[^:]((?!:{2})[^@])+)(@(?<atSign>[^@\s]+))?$';
+      r'^delete'
+      r'(:priority:(?<priority>low|medium|high))?'
+      r'(:cached)?'
+      r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
+      r':(?<atKey>[^@:]((?!:{2})[^@:])+)'
+      r'(@(?<atSign>[^:@\s]+))?'
+      r'$';
   static const monitor = r'^monitor(:(?<epochMillis>\d+))?( (?<regex>.+))?$';
   static const stream =
       r'^stream:((?<operation>init|send|receive|done|resume))?((@(?<receiver>[^@:\s]+)))?( ?namespace:(?<namespace>[\w-]+))?( ?startByte:(?<startByte>\d+))?( (?<streamId>[\w-]*))?( (?<fileName>.* ))?((?<length>\d*))?$';
+
+  // notify:id:123:notifier:SYSTEM:public:email@alice:alice@gmail.com\n
   static const notify =
-      r'^notify:(id:(?<id>[\w\d\-\_]+):)?((?<operation>update|delete):)?(messageType:(?<messageType>key|text):)?(priority:(?<priority>low|medium|high):)?(strategy:(?<strategy>all|latest):)?(latestN:(?<latestN>\d+):)?(notifier:(?<notifier>[^\s:]+):)?(ttln:(?<ttln>\d+):)?(ttl:(?<ttl>\d+):)?(ttb:(?<ttb>\d+):)?(ttr:(?<ttr>(-)?\d+):)?(ccd:(?<ccd>true|false):)?(isEncrypted:(?<isEncrypted>true|false):)?(sharedKeyEnc:(?<sharedKeyEnc>[^:@]+):)?(pubKeyCS:(?<pubKeyCS>[^:@]+):)?(@(?<forAtSign>[^@:\s]*)):(?<atKey>[^:@]((?!:{2})[^@])+)(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
+      r'^notify'
+      r'(:id:(?<id>[\w\d\-\_]+))?'
+      r'(:(?<operation>update|delete))?'
+      r'(:messageType:(?<messageType>key|text))?'
+      r'(:priority:(?<priority>low|medium|high))?'
+      r'(:strategy:(?<strategy>all|latest))?'
+      r'(:latestN:(?<latestN>\d+))?'
+      r'(:notifier:(?<notifier>[^\s:]+))?'
+      r'(:ttln:(?<ttln>\d+))?'
+      '$metadata'
+      r':((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+)))'
+      r':(?<atKey>[^:@]((?!:{2})[^@])+)'
+      r'(@(?<atSign>[^:@\s]+))?'
+      r'(:(?<value>.+))?'
+      r'$';
   static const notifyList =
       r'^notify:list(:(?<fromDate>\d{4}-[01]?\d?-[0123]?\d?))?(:(?<toDate>\d{4}-[01]?\d?-[0123]?\d?))?(:(?<regex>[^:]+))?';
   static const notifyStatus = r'^notify:status:(?<notificationId>\S+)$';
   static const notifyFetch = r'^notify:fetch:(?<notificationId>\S+)$';
   static const notifyAll =
-      r'^notify:all:((?<operation>update|delete):)?(messageType:((?<messageType>key|text):))?(?:ttl:(?<ttl>\d+):)?(?:ttb:(?<ttb>\d+):)?(?:ttr:(?<ttr>-?\d+):)?(?:ccd:(?<ccd>true|false+):)?(?<forAtSign>(([^:\s])+)?(,([^:\s]+))*)(:(?<atKey>[^@:\s]+))(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
+      r'^notify:all:'
+      r'((?<operation>update|delete):)?'
+      r'(messageType:((?<messageType>key|text):))?'
+      r'(?:ttl:(?<ttl>\d+):)?'
+      r'(?:ttb:(?<ttb>\d+):)?'
+      r'(?:ttr:(?<ttr>-?\d+):)?'
+      r'(?:ccd:(?<ccd>true|false+):)?'
+      r'(?<forAtSign>(([^:\s])+)?(,([^:\s]+))*)'
+      r'(:(?<atKey>[^@:\s]+))(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
   static const batch = r'^batch:(?<json>.+)$';
   static const info = r'^info(:brief)?$';
   static const noOp = r'^noop:(?<delayMillis>\d+)$';

--- a/packages/at_commons/lib/src/verb/update_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/update_verb_builder.dart
@@ -2,8 +2,8 @@ import 'dart:collection';
 import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
-import 'package:at_commons/src/utils/string_utils.dart';
 import 'package:at_commons/src/verb/abstract_verb_builder.dart';
+import 'package:meta/meta.dart';
 
 /// Update builder generates a command to update [value] for a key [atKey] in the secondary server of [sharedBy].
 /// Use [getBuilder] method if you want to convert command to a builder.
@@ -41,171 +41,159 @@ import 'package:at_commons/src/verb/abstract_verb_builder.dart';
 ///                      ..value = jsonEncode(myPrefObj)
 ///```
 class UpdateVerbBuilder extends AbstractVerbBuilder {
-  /// Key that represents a user's information. e.g phone, location, email etc.,
-  String? atKey;
-
+  UpdateVerbBuilder() {
+    atKeyObj.metadata!.isBinary = null;
+  }
   /// Value of the key typically in string format. Images, files, etc.,
   /// must be converted to unicode string before storing.
   dynamic value;
 
-  /// AtSign to whom [atKey] has to be shared.
-  String? sharedWith;
+  /// See [AtKey.key]
+  String? get atKey => atKeyObj.key;
+  /// See [AtKey.key]
+  set atKey (String? s) => atKeyObj.key = s;
 
-  /// AtSign of the client user calling this builder.
-  String? sharedBy;
+  /// See [AtKey.sharedWith]
+  String? get sharedWith => atKeyObj.sharedWith;
+  /// See [AtKey.sharedWith]
+  set sharedWith (String? s) => atKeyObj.sharedWith = VerbUtil.formatAtSign(s);
 
-  /// if [isPublic] is true, then [atKey] is accessible by all atSigns.
-  /// if [isPublic] is false, then [atKey] is accessible either by [sharedWith] or [sharedBy]
-  bool isPublic = false;
+  /// See [AtKey.sharedBy]
+  String? get sharedBy => atKeyObj.sharedBy;
+  /// See [AtKey.sharedBy]
+  set sharedBy (String? s) => atKeyObj.sharedBy = VerbUtil.formatAtSign(s);
 
-  /// See [Metadata.isBinary]
-  bool? isBinary;
-
-  /// See [Metadata.isEncrypted]
-  bool? isEncrypted;
+  /// See [AtKey.isLocal]
+  bool get isLocal => atKeyObj.isLocal;
+  /// See [AtKey.isLocal]
+  set isLocal (bool b) => atKeyObj.isLocal = b;
 
   String? operation;
 
   bool isJson = false;
 
-  /// Indicates if the key is local
-  /// If the key is local, the key does not sync between cloud and local secondary
-  bool isLocal = false;
+  @visibleForTesting
+  Metadata get metadata => atKeyObj.metadata!;
 
+  /// See [Metadata.isPublic]
+  bool get isPublic => metadata.isPublic!;
+  /// See [Metadata.isPublic]
+  set isPublic (bool b) => metadata.isPublic = b;
 
+  /// See [Metadata.isBinary]
+  bool? get isBinary => metadata.isBinary;
+  /// See [Metadata.isBinary]
+  set isBinary (bool? b) => metadata.isBinary = b;
+
+  /// See [Metadata.isEncrypted]
+  bool? get isEncrypted => metadata.isEncrypted;
+  /// See [Metadata.isEncrypted]
+  set isEncrypted (bool? b) => metadata.isEncrypted = b;
 
   /// See [Metadata.ttl]
-  int? ttl;
+  int? get ttl => metadata.ttl;
+  /// See [Metadata.ttl]
+  set ttl (int? i) => metadata.ttl = i;
 
   /// See [Metadata.ttb]
-  int? ttb;
+  int? get ttb => metadata.ttb;
+  /// See [Metadata.ttb]
+  set ttb (int? i) => metadata.ttb = i;
 
   /// See [Metadata.ttr]
-  int? ttr;
+  int? get ttr => metadata.ttr;
+  /// See [Metadata.ttr]
+  set ttr (int? i) => metadata.ttr = i;
 
   /// See [Metadata.ccd]
-  bool? ccd;
+  bool? get ccd => metadata.ccd;
+  /// See [Metadata.ccd]
+  set ccd (bool? b) => metadata.ccd = b;
 
   /// See [Metadata.dataSignature]
-  String? dataSignature;
+  String? get dataSignature => metadata.dataSignature;
+  /// See [Metadata.dataSignature]
+  set dataSignature (String? s) => metadata.dataSignature = s;
 
   /// See [Metadata.sharedKeyStatus]
-  String? sharedKeyStatus;
+  String? get sharedKeyStatus => metadata.sharedKeyStatus;
+  /// See [Metadata.sharedKeyStatus]
+  set sharedKeyStatus (String? s) => metadata.sharedKeyStatus = s;
 
   /// See [Metadata.sharedKeyEnc]
-  String? sharedKeyEncrypted;
+  String? get sharedKeyEncrypted => metadata.sharedKeyEnc;
+  /// See [Metadata.sharedKeyEnc]
+  set sharedKeyEncrypted (String? s) => metadata.sharedKeyEnc = s;
 
-  /// checksum of the the public key of [sharedWith] atsign. Will be set only when [sharedWith] is set.
   /// See [Metadata.pubKeyCS]
-  String? pubKeyChecksum;
+  String? get pubKeyChecksum => metadata.pubKeyCS;
+  /// See [Metadata.pubKeyCS]
+  set pubKeyChecksum (String? s) => metadata.pubKeyCS = s;
 
   /// See [Metadata.encoding]
-  String? encoding;
+  String? get encoding => metadata.encoding;
+  /// See [Metadata.encoding]
+  set encoding (String? s) => metadata.encoding = s;
 
   /// See [Metadata.encKeyName]
-  String? encKeyName;
+  String? get encKeyName => metadata.encKeyName;
+  /// See [Metadata.encKeyName]
+  set encKeyName (String? s) => metadata.encKeyName = s;
 
   /// See [Metadata.encAlgo]
-  String? encAlgo;
+  String? get encAlgo => metadata.encAlgo;
+  /// See [Metadata.encAlgo]
+  set encAlgo (String? s) => metadata.encAlgo = s;
 
   /// See [Metadata.ivNonce]
-  String? ivNonce;
+  String? get ivNonce => metadata.ivNonce;
+  /// See [Metadata.ivNonce]
+  set ivNonce (String? s) => metadata.ivNonce = s;
 
   /// See [Metadata.skeEncKeyName]
-  String? skeEncKeyName;
+  String? get skeEncKeyName => metadata.skeEncKeyName;
+  /// See [Metadata.skeEncKeyName]
+  set skeEncKeyName (String? s) => metadata.skeEncKeyName = s;
 
   /// See [Metadata.skeEncAlgo]
-  String? skeEncAlgo;
+  String? get skeEncAlgo => metadata.skeEncAlgo;
+  /// See [Metadata.skeEncAlgo]
+  set skeEncAlgo (String? s) => metadata.skeEncAlgo = s;
 
   @override
   String buildCommand() {
+    String atKeyName = buildKey();
     if (isJson) {
-      var updateParams = UpdateParams();
-      var key = '';
-      if (sharedWith != null) {
-        key += '${VerbUtil.formatAtSign(sharedWith)}:';
-      }
-      key += atKey!;
-      if (sharedBy != null) {
-        key += '${VerbUtil.formatAtSign(sharedBy)}';
-      }
-      updateParams.atKey = key;
-      updateParams.value = value;
-      updateParams.sharedBy = sharedBy;
-      updateParams.sharedWith = sharedWith;
-      final metadata = Metadata();
-      metadata.isPublic = isPublic;
-      if (isEncrypted != null) {
-        metadata.isEncrypted = isEncrypted!;
-      }
-      if (isBinary != null) {
-        metadata.isBinary = isBinary!;
-      }
-      metadata.ttl = ttl;
-      metadata.ttb = ttb;
-      metadata.ttr = ttr;
-      metadata.ccd = ccd;
-      metadata.dataSignature = dataSignature;
-      metadata.sharedKeyStatus = sharedKeyStatus;
-      metadata.sharedKeyEnc = sharedKeyEncrypted;
-      metadata.pubKeyCS = pubKeyChecksum;
-      metadata.encoding = encoding;
-      metadata.encKeyName = encKeyName;
-      metadata.encAlgo = encAlgo;
-      metadata.ivNonce = ivNonce;
-      metadata.skeEncKeyName = skeEncKeyName;
-      metadata.skeEncAlgo = skeEncAlgo;
-      updateParams.metadata = metadata;
+      var updateParams = UpdateParams()
+      ..atKey = atKeyName
+      ..value = value
+      ..sharedBy = sharedBy
+      ..sharedWith = sharedWith
+      ..metadata = metadata;
       var json = updateParams.toJson();
       var command = 'update:json:${jsonEncode(json)}\n';
       return command;
+    } else {
+      var metadataFragment = atKeyObj.metadata!.toAtProtocolFragment();
+      var command = 'update$metadataFragment:$atKeyName $value\n';
+      return command;
     }
-    var command = 'update';
-    command += buildMetadataString();
-    command += ':${buildKey()}';
-    command += ' $value\n';
-    return command;
   }
 
+  /// Get the string representation (e.g. `@bob:city.address.my_app@alice`) of the key
+  /// for which this update command is being built.
+  ///
+  /// First of all calls [validateKey]. If validation fails an exception will be thrown. If not
+  /// then we return the string representation of the key.
   String buildKey() {
-    if (atKeyObj.key != null) {
-      return atKeyObj.toString();
-    }
-    super.atKeyObj
-      ..key = atKey
-      ..sharedWith = VerbUtil.formatAtSign(sharedWith)
-      ..sharedBy = VerbUtil.formatAtSign(sharedBy)
-      ..metadata = (Metadata()
-        ..isPublic = isPublic
-        ..isBinary = isBinary
-        ..isEncrypted = isEncrypted
-        ..ttl = ttl
-        ..ttb = ttb
-        ..ttr = ttr
-        ..ccd = ccd
-        ..dataSignature = dataSignature
-        ..sharedKeyStatus = sharedKeyStatus
-        ..sharedKeyEnc = sharedKeyEncrypted
-        ..pubKeyCS = pubKeyChecksum
-        ..encoding = encoding
-        ..encKeyName = encKeyName
-        ..encAlgo = encAlgo
-        ..ivNonce = ivNonce
-        ..skeEncKeyName = skeEncKeyName
-        ..skeEncAlgo = skeEncAlgo
-      )
-      ..isLocal = isLocal;
-    // If validation is successful, build the command and returns;
-    // else throws exception.
     validateKey();
     return super.atKeyObj.toString();
   }
 
   String buildCommandForMeta() {
-    var command = 'update:meta';
-    command += ':${buildKey()}';
-    command += buildMetadataString();
-    command += '\n';
+    String atKeyName = buildKey();
+    var metadataFragment = atKeyObj.metadata!.toAtProtocolFragment();
+    var command = 'update:meta:$atKeyName$metadataFragment\n';
     return command;
   }
 
@@ -284,63 +272,6 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
       return true;
     }
     return false;
-  }
-
-  /// Builds the metadata part of the command.
-  String buildMetadataString() {
-    String metadataString = '';
-
-    // NB The order of the verb parameters is important - it MUST match the order
-    // in the regular expressions [VerbSyntax.update] and [VerbSyntax.update_meta]
-    if (ttl != null) {
-      metadataString += ':ttl:$ttl';
-    }
-    if (ttb != null) {
-      metadataString += ':ttb:$ttb';
-    }
-    if (ttr != null) {
-      metadataString += ':ttr:$ttr';
-    }
-    if (ccd != null) {
-      metadataString += ':ccd:$ccd';
-    }
-    if (dataSignature.isNotNullOrEmpty) {
-      metadataString += ':$PUBLIC_DATA_SIGNATURE:$dataSignature';
-    }
-    if (sharedKeyStatus.isNotNullOrEmpty) {
-      metadataString += ':$SHARED_KEY_STATUS:$sharedKeyStatus';
-    }
-    if (isBinary != null) {
-      metadataString += ':isBinary:$isBinary';
-    }
-    if (isEncrypted != null) {
-      metadataString += ':isEncrypted:$isEncrypted';
-    }
-    if (sharedKeyEncrypted.isNotNullOrEmpty) {
-      metadataString += ':$SHARED_KEY_ENCRYPTED:$sharedKeyEncrypted';
-    }
-    if (pubKeyChecksum.isNotNullOrEmpty) {
-      metadataString += ':$SHARED_WITH_PUBLIC_KEY_CHECK_SUM:$pubKeyChecksum';
-    }
-    if (encoding.isNotNullOrEmpty) {
-      metadataString += ':$ENCODING:$encoding';
-    }
-    if (encKeyName.isNotNullOrEmpty) {
-      metadataString += ':$ENCRYPTING_KEY_NAME:$encKeyName';
-    }
-    if (encAlgo.isNotNullOrEmpty) {
-      metadataString += ':$ENCRYPTING_ALGO:$encAlgo';
-    }
-    if (ivNonce.isNotNullOrEmpty) {
-      metadataString += ':$IV_OR_NONCE:$ivNonce';
-    }
-    if (skeEncKeyName.isNotNullOrEmpty) {
-      metadataString += ':$SHARED_KEY_ENCRYPTED_ENCRYPTING_KEY_NAME:$skeEncKeyName';
-    }
-    if (skeEncAlgo.isNotNullOrEmpty) {
-      metadataString += ':$SHARED_KEY_ENCRYPTED_ENCRYPTING_ALGO:$skeEncAlgo';
-    }
-    return metadataString;
   }
 
   @override

--- a/packages/at_commons/lib/src/verb/update_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/update_verb_builder.dart
@@ -2,8 +2,7 @@ import 'dart:collection';
 import 'dart:convert';
 
 import 'package:at_commons/at_commons.dart';
-import 'package:at_commons/src/verb/abstract_verb_builder.dart';
-import 'package:meta/meta.dart';
+import 'package:at_commons/src/verb/metadata_using_verb_builder.dart';
 
 /// Update builder generates a command to update [value] for a key [atKey] in the secondary server of [sharedBy].
 /// Use [getBuilder] method if you want to convert command to a builder.
@@ -40,28 +39,10 @@ import 'package:meta/meta.dart';
 ///                      ..sharedBy = '@bob'
 ///                      ..value = jsonEncode(myPrefObj)
 ///```
-class UpdateVerbBuilder extends AbstractVerbBuilder {
-  UpdateVerbBuilder() {
-    atKeyObj.metadata!.isBinary = null;
-  }
+class UpdateVerbBuilder extends MetadataUsingVerbBuilder {
   /// Value of the key typically in string format. Images, files, etc.,
   /// must be converted to unicode string before storing.
   dynamic value;
-
-  /// See [AtKey.key]
-  String? get atKey => atKeyObj.key;
-  /// See [AtKey.key]
-  set atKey (String? s) => atKeyObj.key = s;
-
-  /// See [AtKey.sharedWith]
-  String? get sharedWith => atKeyObj.sharedWith;
-  /// See [AtKey.sharedWith]
-  set sharedWith (String? s) => atKeyObj.sharedWith = VerbUtil.formatAtSign(s);
-
-  /// See [AtKey.sharedBy]
-  String? get sharedBy => atKeyObj.sharedBy;
-  /// See [AtKey.sharedBy]
-  set sharedBy (String? s) => atKeyObj.sharedBy = VerbUtil.formatAtSign(s);
 
   /// See [AtKey.isLocal]
   bool get isLocal => atKeyObj.isLocal;
@@ -71,94 +52,6 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
   String? operation;
 
   bool isJson = false;
-
-  @visibleForTesting
-  Metadata get metadata => atKeyObj.metadata!;
-
-  /// See [Metadata.isPublic]
-  bool get isPublic => metadata.isPublic!;
-  /// See [Metadata.isPublic]
-  set isPublic (bool b) => metadata.isPublic = b;
-
-  /// See [Metadata.isBinary]
-  bool? get isBinary => metadata.isBinary;
-  /// See [Metadata.isBinary]
-  set isBinary (bool? b) => metadata.isBinary = b;
-
-  /// See [Metadata.isEncrypted]
-  bool? get isEncrypted => metadata.isEncrypted;
-  /// See [Metadata.isEncrypted]
-  set isEncrypted (bool? b) => metadata.isEncrypted = b;
-
-  /// See [Metadata.ttl]
-  int? get ttl => metadata.ttl;
-  /// See [Metadata.ttl]
-  set ttl (int? i) => metadata.ttl = i;
-
-  /// See [Metadata.ttb]
-  int? get ttb => metadata.ttb;
-  /// See [Metadata.ttb]
-  set ttb (int? i) => metadata.ttb = i;
-
-  /// See [Metadata.ttr]
-  int? get ttr => metadata.ttr;
-  /// See [Metadata.ttr]
-  set ttr (int? i) => metadata.ttr = i;
-
-  /// See [Metadata.ccd]
-  bool? get ccd => metadata.ccd;
-  /// See [Metadata.ccd]
-  set ccd (bool? b) => metadata.ccd = b;
-
-  /// See [Metadata.dataSignature]
-  String? get dataSignature => metadata.dataSignature;
-  /// See [Metadata.dataSignature]
-  set dataSignature (String? s) => metadata.dataSignature = s;
-
-  /// See [Metadata.sharedKeyStatus]
-  String? get sharedKeyStatus => metadata.sharedKeyStatus;
-  /// See [Metadata.sharedKeyStatus]
-  set sharedKeyStatus (String? s) => metadata.sharedKeyStatus = s;
-
-  /// See [Metadata.sharedKeyEnc]
-  String? get sharedKeyEncrypted => metadata.sharedKeyEnc;
-  /// See [Metadata.sharedKeyEnc]
-  set sharedKeyEncrypted (String? s) => metadata.sharedKeyEnc = s;
-
-  /// See [Metadata.pubKeyCS]
-  String? get pubKeyChecksum => metadata.pubKeyCS;
-  /// See [Metadata.pubKeyCS]
-  set pubKeyChecksum (String? s) => metadata.pubKeyCS = s;
-
-  /// See [Metadata.encoding]
-  String? get encoding => metadata.encoding;
-  /// See [Metadata.encoding]
-  set encoding (String? s) => metadata.encoding = s;
-
-  /// See [Metadata.encKeyName]
-  String? get encKeyName => metadata.encKeyName;
-  /// See [Metadata.encKeyName]
-  set encKeyName (String? s) => metadata.encKeyName = s;
-
-  /// See [Metadata.encAlgo]
-  String? get encAlgo => metadata.encAlgo;
-  /// See [Metadata.encAlgo]
-  set encAlgo (String? s) => metadata.encAlgo = s;
-
-  /// See [Metadata.ivNonce]
-  String? get ivNonce => metadata.ivNonce;
-  /// See [Metadata.ivNonce]
-  set ivNonce (String? s) => metadata.ivNonce = s;
-
-  /// See [Metadata.skeEncKeyName]
-  String? get skeEncKeyName => metadata.skeEncKeyName;
-  /// See [Metadata.skeEncKeyName]
-  set skeEncKeyName (String? s) => metadata.skeEncKeyName = s;
-
-  /// See [Metadata.skeEncAlgo]
-  String? get skeEncAlgo => metadata.skeEncAlgo;
-  /// See [Metadata.skeEncAlgo]
-  set skeEncAlgo (String? s) => metadata.skeEncAlgo = s;
 
   @override
   String buildCommand() {

--- a/packages/at_commons/lib/src/verb/update_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/update_verb_builder.dart
@@ -224,7 +224,7 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
     if (verbParams == null) {
       return null;
     }
-    builder.isPublic = command.contains('public:');
+    builder.isPublic = verbParams[IS_PUBLIC] == 'true';
     builder.sharedWith = VerbUtil.formatAtSign(verbParams[FOR_AT_SIGN]);
     builder.sharedBy = VerbUtil.formatAtSign(verbParams[AT_SIGN]);
     builder.atKey = verbParams[AT_KEY];

--- a/packages/at_commons/lib/src/verb/update_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/update_verb_builder.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_commons/src/verb/metadata_using_verb_builder.dart';
 
+
 /// Update builder generates a command to update [value] for a key [atKey] in the secondary server of [sharedBy].
 /// Use [getBuilder] method if you want to convert command to a builder.
 ///
@@ -105,7 +106,7 @@ class UpdateVerbBuilder extends MetadataUsingVerbBuilder {
     if (verbParams == null) {
       return null;
     }
-    builder.isPublic = verbParams[IS_PUBLIC] == 'true';
+    builder.isPublic = verbParams[PUBLIC_SCOPE_PARAM] == 'public';
     builder.sharedWith = VerbUtil.formatAtSign(verbParams[FOR_AT_SIGN]);
     builder.sharedBy = VerbUtil.formatAtSign(verbParams[AT_SIGN]);
     builder.atKey = verbParams[AT_KEY];

--- a/packages/at_commons/lib/src/verb/verb_util.dart
+++ b/packages/at_commons/lib/src/verb/verb_util.dart
@@ -14,7 +14,10 @@ class VerbUtil {
     var paramsMap = HashMap<String, String?>();
     for (var f in matches) {
       for (var name in f.groupNames) {
-        paramsMap.putIfAbsent(name, () => f.namedGroup(name));
+        var namedGroup = f.namedGroup(name);
+        if (namedGroup != null) {
+          paramsMap.putIfAbsent(name, () => f.namedGroup(name));
+        }
       }
     }
     return paramsMap;
@@ -28,9 +31,6 @@ class VerbUtil {
     }
     var verbParams = _processMatches(regexMatches);
 
-    verbParams[IS_PUBLIC] =
-      verbParams[PUBLIC_SCOPE_PARAM] == 'public' ?
-      'true' : 'false';
     return verbParams;
   }
 

--- a/packages/at_commons/lib/src/verb/verb_util.dart
+++ b/packages/at_commons/lib/src/verb/verb_util.dart
@@ -1,5 +1,7 @@
 import 'dart:collection';
 
+import '../at_constants.dart';
+
 class VerbUtil {
   static const String newLineReplacePattern = '~NL~';
   static Iterable<RegExpMatch> _getMatches(RegExp regex, String command) {
@@ -25,6 +27,10 @@ class VerbUtil {
       return null;
     }
     var verbParams = _processMatches(regexMatches);
+
+    verbParams[IS_PUBLIC] =
+      verbParams[PUBLIC_SCOPE_PARAM] == 'public' ?
+      'true' : 'false';
     return verbParams;
   }
 

--- a/packages/at_commons/test/notify_verb_builder_test.dart
+++ b/packages/at_commons/test/notify_verb_builder_test.dart
@@ -13,8 +13,15 @@ void main() {
         ..isPublic = true
         ..atKey = 'email'
         ..sharedBy = 'alice';
-      expect(notifyVerbBuilder.buildCommand(),
+      var command = notifyVerbBuilder.buildCommand();
+      expect(command,
           'notify:id:123:notifier:SYSTEM:public:email@alice:alice@gmail.com\n');
+      var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
+      expect(params[ID], '123');
+      expect(params[VALUE], 'alice@gmail.com');
+      expect(params[IS_PUBLIC], 'true');
+      expect(params[AT_KEY], 'email');
+      expect(params[AT_SIGN], 'alice');
     });
 
     test('notify public key with ttl', () {

--- a/packages/at_commons/test/notify_verb_builder_test.dart
+++ b/packages/at_commons/test/notify_verb_builder_test.dart
@@ -17,11 +17,13 @@ void main() {
       expect(command,
           'notify:id:123:notifier:SYSTEM:public:email@alice:alice@gmail.com\n');
       var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
+      expect(params.length, 6);
       expect(params[ID], '123');
       expect(params[VALUE], 'alice@gmail.com');
-      expect(params[IS_PUBLIC], 'true');
+      expect(params[PUBLIC_SCOPE_PARAM], 'public');
       expect(params[AT_KEY], 'email');
       expect(params[AT_SIGN], 'alice');
+      expect(params[NOTIFIER], 'SYSTEM');
     });
 
     test('notify public key with ttl', () {
@@ -32,8 +34,18 @@ void main() {
         ..atKey = 'email'
         ..sharedBy = 'alice'
         ..ttl = 1000;
-      expect(notifyVerbBuilder.buildCommand(),
+      var command = notifyVerbBuilder.buildCommand();
+      expect(command,
           'notify:id:123:notifier:SYSTEM:ttl:1000:public:email@alice:alice@gmail.com\n');
+      var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
+      expect(params.length, 7);
+      expect(params[ID], '123');
+      expect(params[VALUE], 'alice@gmail.com');
+      expect(params[PUBLIC_SCOPE_PARAM], 'public');
+      expect(params[AT_KEY], 'email');
+      expect(params[AT_SIGN], 'alice');
+      expect(params[AT_TTL], '1000');
+      expect(params[NOTIFIER], 'SYSTEM');
     });
 
     test('notify shared key command', () {
@@ -45,8 +57,19 @@ void main() {
         ..sharedWith = 'bob'
         ..pubKeyChecksum = '123'
         ..sharedKeyEncrypted = 'abc';
-      expect(notifyVerbBuilder.buildCommand(),
+      var command = notifyVerbBuilder.buildCommand();
+      expect(command,
           'notify:id:123:notifier:SYSTEM:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');
+      var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
+      expect(params.length, 8);
+      expect(params[ID], '123');
+      expect(params[VALUE], 'alice@atsign.com');
+      expect(params[AT_KEY], 'email');
+      expect(params[AT_SIGN], 'alice');
+      expect(params[FOR_AT_SIGN], 'bob');
+      expect(params[NOTIFIER], 'SYSTEM');
+      expect(params[SHARED_WITH_PUBLIC_KEY_CHECK_SUM], '123');
+      expect(params[SHARED_KEY_ENCRYPTED], 'abc');
     });
 
     test('notify text message with isEncrypted set to true', () {
@@ -59,8 +82,60 @@ void main() {
         ..pubKeyChecksum = '123'
         ..sharedKeyEncrypted = 'abc'
         ..isTextMessageEncrypted = true;
-      expect(notifyVerbBuilder.buildCommand(),
+      var command = notifyVerbBuilder.buildCommand();
+      expect(command,
           'notify:id:123:notifier:SYSTEM:isEncrypted:true:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');
+      var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
+      expect(params.length, 9);
+      expect(params[PUBLIC_SCOPE_PARAM], null);
+      expect(params[ID], '123');
+      expect(params[VALUE], 'alice@atsign.com');
+      expect(params[AT_KEY], 'email');
+      expect(params[AT_SIGN], 'alice');
+      expect(params[FOR_AT_SIGN], 'bob');
+      expect(params[NOTIFIER], 'SYSTEM');
+      expect(params[IS_ENCRYPTED], 'true');
+      expect(params[SHARED_WITH_PUBLIC_KEY_CHECK_SUM], '123');
+      expect(params[SHARED_KEY_ENCRYPTED], 'abc');
+    });
+
+    test('notify with every piece of encryption metadata', () {
+      var notifyVerbBuilder = NotifyVerbBuilder()
+        ..id = '123'
+        ..value = 'alice@atsign.com'
+        ..atKey = 'email'
+        ..sharedBy = 'alice'
+        ..sharedWith = 'bob'
+        ..pubKeyChecksum = '123'
+        ..sharedKeyEncrypted = 'abc'
+        ..encKeyName = 'ekn'
+        ..encAlgo = 'ea'
+        ..ivNonce = 'ivn'
+        ..skeEncKeyName = 'ske_ekn'
+        ..skeEncAlgo = 'ske_ea';
+      var command = notifyVerbBuilder.buildCommand();
+      expect(command,
+          'notify:id:123:notifier:SYSTEM'
+              ':sharedKeyEnc:abc:pubKeyCS:123'
+              ':encKeyName:ekn:encAlgo:ea:ivNonce:ivn'
+              ':skeEncKeyName:ske_ekn:skeEncAlgo:ske_ea'
+              ':@bob:email@alice:alice@atsign.com\n');
+      var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
+      expect(params.length, 13);
+      expect(params[PUBLIC_SCOPE_PARAM], null);
+      expect(params[ID], '123');
+      expect(params[VALUE], 'alice@atsign.com');
+      expect(params[AT_KEY], 'email');
+      expect(params[AT_SIGN], 'alice');
+      expect(params[FOR_AT_SIGN], 'bob');
+      expect(params[NOTIFIER], 'SYSTEM');
+      expect(params[SHARED_WITH_PUBLIC_KEY_CHECK_SUM], '123');
+      expect(params[SHARED_KEY_ENCRYPTED], 'abc');
+      expect(params[ENCRYPTING_KEY_NAME], 'ekn');
+      expect(params[ENCRYPTING_ALGO], 'ea');
+      expect(params[IV_OR_NONCE], 'ivn');
+      expect(params[SHARED_KEY_ENCRYPTED_ENCRYPTING_KEY_NAME], 'ske_ekn');
+      expect(params[SHARED_KEY_ENCRYPTED_ENCRYPTING_ALGO], 'ske_ea');
     });
   });
 

--- a/packages/at_commons/test/update_verb_builder_test.dart
+++ b/packages/at_commons/test/update_verb_builder_test.dart
@@ -368,7 +368,7 @@ void main() {
       expect(updateVerbBuilder.buildKey(), 'public:phone@alice');
     });
 
-    UpdateVerbBuilder createBuilderWithAllMetadata() {
+    UpdateVerbBuilder createBuilderWithAllMetadata({String? sharedWith}) {
       var ttl = 12345;
       var ttb = 54321;
       var ccd = false;
@@ -388,7 +388,8 @@ void main() {
       return UpdateVerbBuilder()
         ..atKey = 'phone.details.wavi'
         ..sharedBy = '@alice'
-        ..sharedWith = '@bob'
+        ..sharedWith = sharedWith
+        ..isPublic = (sharedWith == null)
         ..ttl=ttl
         ..ttb=ttb
         ..ccd=ccd
@@ -409,7 +410,7 @@ void main() {
       ;
     }
     test('verify metadata is fully passed from builder to the atKeyObj which is built by buildKey', () {
-      var updateVerbBuilder = createBuilderWithAllMetadata();
+      var updateVerbBuilder = createBuilderWithAllMetadata(sharedWith: '@bob');
       expect(updateVerbBuilder.buildKey(), '@bob:phone.details.wavi@alice');
       expect(updateVerbBuilder.atKeyObj.metadata!.ttl, updateVerbBuilder.ttl);
       expect(updateVerbBuilder.atKeyObj.metadata!.ttb, updateVerbBuilder.ttb);
@@ -429,28 +430,50 @@ void main() {
       expect(updateVerbBuilder.atKeyObj.metadata!.skeEncAlgo, updateVerbBuilder.skeEncAlgo);
     });
 
-    test('verify round trip from builder, to command for update, to builder', () {
-      var initialBuilder = createBuilderWithAllMetadata();
-      var command = initialBuilder.buildCommand();
-      var roundTrippedBuilder = UpdateVerbBuilder.getBuilder(command.trim());
-      expect(initialBuilder == roundTrippedBuilder, true);
-    });
+    group('A group of tests to verify round-tripping of update commands from buildCommand and getBuilder', () {
+      UpdateVerbBuilder roundTripUpdateTest({String? sharedWith}) {
+        var initialBuilder = createBuilderWithAllMetadata(sharedWith: sharedWith);
+        var command = initialBuilder.buildCommand();
+        var roundTrippedBuilder = UpdateVerbBuilder.getBuilder(command.trim());
+        expect(initialBuilder == roundTrippedBuilder, true);
+        return roundTrippedBuilder!;
+      }
+      test('verify round trip from builder, to command for update, back to builder, for public key', () {
+        var roundTrippedBuilder = roundTripUpdateTest(sharedWith: null);
+        expect(roundTrippedBuilder.isPublic, true);
+      });
 
-    test('verify round trip from builder, to command for update meta, to builder', () {
-      var initialBuilder = createBuilderWithAllMetadata();
-      initialBuilder.operation = UPDATE_META;
+      test('verify round trip from builder, to command for update, back to builder, for shared key', () {
+        var roundTrippedBuilder = roundTripUpdateTest(sharedWith: '@bob');
+        expect(roundTrippedBuilder.isPublic, false);
+      });
 
-      // When the update:meta command is built, it will NOT include the value, so
-      // we'll make two assertions: (1) builder after round-tripping via buildCommandForMeta()
-      // will NOT be the same as the initial builder, and (2) builder after round-tripping via
-      // buildCommandForMeta() WILL be the same as the initial builder, if the `value` in the
-      // initial builder is set to null
-      var command = initialBuilder.buildCommandForMeta();
-      var roundTrippedBuilder = UpdateVerbBuilder.getBuilder(command.trim());
-      expect(initialBuilder == roundTrippedBuilder, false);
+      UpdateVerbBuilder roundTripUpdateMetaTest({String? sharedWith}) {
+        var initialBuilder = createBuilderWithAllMetadata(sharedWith: sharedWith);
+        initialBuilder.operation = UPDATE_META;
 
-      initialBuilder.value = null;
-      expect(initialBuilder == roundTrippedBuilder, true);
+        // When the update:meta command is built, it will NOT include the value, so
+        // we'll make two assertions: (1) builder after round-tripping via buildCommandForMeta()
+        // will NOT be the same as the initial builder, and (2) builder after round-tripping via
+        // buildCommandForMeta() WILL be the same as the initial builder, if the `value` in the
+        // initial builder is set to null
+        var command = initialBuilder.buildCommandForMeta();
+        var roundTrippedBuilder = UpdateVerbBuilder.getBuilder(command.trim());
+        expect(initialBuilder == roundTrippedBuilder, false);
+
+        initialBuilder.value = null;
+        expect(initialBuilder == roundTrippedBuilder, true);
+
+        return roundTrippedBuilder!;
+      }
+      test('verify round trip from builder, to command for update meta, back to builder, for public key', () {
+        var roundTrippedBuilder = roundTripUpdateMetaTest(sharedWith: null);
+        expect(roundTrippedBuilder.isPublic, true);
+      });
+      test('verify round trip from builder, to command for update meta, back to builder, for shared key', () {
+        var roundTrippedBuilder = roundTripUpdateMetaTest(sharedWith: '@bob');
+        expect(roundTrippedBuilder.isPublic, false);
+      });
     });
   });
 }

--- a/packages/at_commons/test/update_verb_builder_test.dart
+++ b/packages/at_commons/test/update_verb_builder_test.dart
@@ -277,38 +277,30 @@ void main() {
                   'When isLocal is set to true, cannot set isPublic to true or set a non-null sharedWith')));
     });
 
-    test(
-        'test to verify local key with sharedWith populated throws invalid atkey exception',
-        () {
-      var updateVerbBuilder = UpdateVerbBuilder()
-        ..isLocal = true
-        ..sharedWith = '@alice'
-        ..atKey = 'phone'
-        ..sharedBy = '@bob';
-
-      expect(
-          () => updateVerbBuilder.buildCommand(),
-          throwsA(predicate((dynamic e) =>
-              e is InvalidAtKeyException &&
-              e.message ==
-                  'sharedWith must be null when isLocal is set to true')));
+    test('test to verify local key with sharedWith populated throws invalid atkey exception', () {
+      expect(() {
+        UpdateVerbBuilder()
+          ..isLocal = true
+          ..sharedWith = '@alice'
+          ..atKey = 'phone'
+          ..sharedBy = '@bob';
+      },
+          throwsA(predicate(
+              (dynamic e) => e is InvalidAtKeyException
+                  && e.message == 'isLocal or isPublic cannot be true when sharedWith is set')));
     });
 
-    test(
-        'test to verify isPublic set to true with sharedWith populated throws invalid atkey exception',
-        () {
-      var updateVerbBuilder = UpdateVerbBuilder()
-        ..isPublic = true
-        ..sharedWith = '@alice'
-        ..atKey = 'phone'
-        ..sharedBy = '@bob';
-
-      expect(
-          () => updateVerbBuilder.buildCommand(),
-          throwsA(predicate((dynamic e) =>
-              e is InvalidAtKeyException &&
-              e.message ==
-                  'When isPublic is set to true, sharedWith cannot be populated')));
+    test('test to verify isPublic set to true with sharedWith populated throws invalid atkey exception', () {
+      expect(() {
+        UpdateVerbBuilder()
+          ..isPublic = true
+          ..sharedWith = '@alice'
+          ..atKey = 'phone'
+          ..sharedBy = '@bob';
+      },
+          throwsA(predicate(
+              (dynamic e) => e is InvalidAtKeyException
+                  && e.message == 'isLocal or isPublic cannot be true when sharedWith is set')));
     });
 
     test('test to verify Key cannot be null or empty', () {


### PR DESCRIPTION
Follow-up to #277

**- What I did**
feat: Added new encryption metadata to the `notify` verb syntax

**- How I did it**
* refactor: Some more tidying up of regexes in syntax.dart for readability and maintainability. Added `metadataFragment` to eliminate some duplicate code for maintainability.
* feat: Added named regex group `publicScope` to match 'public' in the appropriate places. This will enable tightening of code like this in various server-side verb handlers from `if (command.contains('public:'))` to `if (verbParams['publicScope'] == 'public')`
* refactor: In UpdateVerbBuilder.getBuilder, replaced `builder.isPublic = command.contains('public:');` with `builder.isPublic = verbParams[PUBLIC_SCOPE_PARAM] == 'public';`
* test: Added some additional round-trip tests for UpdateVerbBuilder
* test: Added round-trip assertions to NotifyVerbBuilder syntax tests, and added some new tests
* feat: Simplified and clarified regex for update and delete verbs by being more explicit in the handling of the very small number of exceptions (`privatekey:at_pkam_publickey` for update verb, and `privatekey:at_secret` for delete verb)
* feat: Added toAtProtocolFragment method to Metadata which emits the metadata part of an update / update:meta / notify command
* refactor: UpdateVerbBuilder and NotifyVerbBuilder to reuse common code fragments (especially Metadata.toAtProtocolFragment), eliminate redundant and/or duplicated instance variables for metadata attributes etc
refactor: Use dart:core StringBuffer when building commands instead of using += to create new strings. **Note:** There is also a class in the at_commons package called StringBuffer. This is confusing at best, needs to be deprecated away, and a new class (AtStringBuffer) created instead

**- How to verify it**
- [x] Checks pass for this PR
- [x] Backwards compatibility
    Other packages which depend on at_commons should not need to make any change in order for their checks to pass. So we need checks for at_client_sdk, at_libraries and at_server repos all to pass when they are using this at_commons branch via dependency override
  - [x] at_client_sdk https://github.com/atsign-foundation/at_client_sdk/pull/853
  - [x] at_libraries https://github.com/atsign-foundation/at_libraries/pull/290
  - [x] at_server https://github.com/atsign-foundation/at_server/pull/1174

**- Description for the changelog**
feat: Added new encryption metadata to the `notify` verb syntax
