### PR TITLE
fix: update regex of update and update_meta

### DIFF
--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -101,6 +101,9 @@ class AtKey {
   }
 
   @override
+  ///Generates a String version of the AtKey instance
+  ///Varies depending on the parameters provided
+  ///Converts the entire key to lowercase once toString is called
   String toString() {
     if (key.isNullOrEmpty) {
       throw InvalidAtKeyException('Key cannot be null or empty');

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -52,7 +52,7 @@ class VerbSyntax {
       r'|'
       r'^update'
       '$metadataFragment'
-      r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
+      r'(:((?<publicScope>public)|((?<forAtSign>@[^:@\s]+))))?'
       r':(?<atKey>(([^:@\s]+)|(privatekey:at_pkam_publickey)))'
       r'(@(?<atSign>[^:@\s]+))?'
       r' (?<value>.+)'
@@ -61,7 +61,7 @@ class VerbSyntax {
   // ignore: constant_identifier_names
   static const update_meta =
       r'^update:meta'
-      r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
+      r'(:((?<publicScope>public)|((?<forAtSign>@[^:@\s]+))))?'
       r':(?<atKey>[^:@]((?!:{2})[^:@])+)'
       r'@(?<atSign>[^:@\s]+)'
       '$metadataFragment'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- updated the regexes of the update verb and update_meta verb. Previously the '@' in the atsign was not captured by the **_forAtsign_** name-capturing group.

**- How to verify it**
tests yet to come

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- fix: update regex of update and update_meta