### PR TITLE
build: update CHANGELOG and pubpsec for at_commons version 3.0.35

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.0.35
 - feat: enforce lowercase on AtKey(all key types included)
 - fix: incorrect behaviour of cached:public keys in AtKey.fromString()
+- feat: Added new fields to Metadata
+- feat: Added new encryption metadata to the syntax for notify, update and update:meta verbs
 ## 3.0.34
 - feat: New server-side exception ServerIsPausedException, error code AT0024
 ## 3.0.33

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.34
+version: 3.0.35
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 


### PR DESCRIPTION
**- What I did**
build: update CHANGELOG and pubpsec for at_commons version 3.0.35

**- How to verify it**
CHANGELOG should have entries for 3.0.35; pubspec version should be 3.0.35

