### PR TITLE
refactor: Fixed lint warnings by removing unused imports

### DIFF
--- a/packages/at_commons/lib/src/verb/metadata_using_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/metadata_using_verb_builder.dart
@@ -1,5 +1,3 @@
-import 'package:meta/meta.dart';
-
 import '../keystore/at_key.dart';
 import 'abstract_verb_builder.dart';
 import 'verb_util.dart';

--- a/packages/at_commons/lib/src/verb/verb_util.dart
+++ b/packages/at_commons/lib/src/verb/verb_util.dart
@@ -1,7 +1,5 @@
 import 'dart:collection';
 
-import '../at_constants.dart';
-
 class VerbUtil {
   static const String newLineReplacePattern = '~NL~';
   static Iterable<RegExpMatch> _getMatches(RegExp regex, String command) {


### PR DESCRIPTION
**- What I did**
refactor: Fixed lint warnings by removing unused imports
