### PR TITLE
feat: Added AT0024 to exception_utils.get

### DIFF
--- a/packages/at_commons/lib/src/exception/at_exception_utils.dart
+++ b/packages/at_commons/lib/src/exception/at_exception_utils.dart
@@ -36,6 +36,8 @@ class AtExceptionUtils {
         return IllegalArgumentException(errorDescription);
       case 'AT0023':
         return AtTimeoutException(errorDescription);
+      case 'AT0024':
+        return ServerIsPausedException(errorDescription);
       case 'AT0401':
         return UnAuthenticatedException(errorDescription);
       default:


### PR DESCRIPTION
**- What I did**
feat: Added AT0024 to exception_utils.get so that it will generate a ServerIsPausedException rather than a generic AtException

**- How to verify it**
Tests pass

**- Description for the changelog**
feat: Added AT0024 to exception_utils.get so that it will generate a ServerIsPausedException rather than a generic AtException
