### PR TITLE
fix: Add 'configkey' to list of reserved keys for key validation purposes

### DIFF
--- a/packages/at_cli/CHANGELOG.md
+++ b/packages/at_cli/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+- Use latest packages
+- Fixed lint warnings
 ## 1.0.0
 - initial version
 ## 1.1.0

--- a/packages/at_cli/bin/main.dart
+++ b/packages/at_cli/bin/main.dart
@@ -9,7 +9,6 @@ import 'package:at_utils/at_logger.dart';
 void main(List<String> arguments) async {
   AtSignLogger.root_level = 'severe';
   await ConfigUtil.init();
-  var logger = AtSignLogger('AtCli');
   try {
     var parsedArgs = CommandLineParser.getParserResults(arguments);
     if (parsedArgs == null || parsedArgs.arguments.isEmpty) {
@@ -18,16 +17,14 @@ void main(List<String> arguments) async {
     }
     var currentAtSign = _getCurrentAtSign(parsedArgs).trim();
     var preferences = await _getAtCliPreference(parsedArgs);
-    if (preferences.authKeyFile != null) {
-      if (!(await File(preferences.authKeyFile).exists())) {
-        print('Given Authentication key file is not exists. '
-            '\nPlease update correct file path in config or provide as commandline argument');
-        print('Usage: \n ${CommandLineParser.getUsage()}');
-        exit(0);
-      }
+    if (!(await File(preferences.authKeyFile).exists())) {
+      print('Given Authentication key file is not exists. '
+          '\nPlease update correct file path in config or provide as commandline argument');
+      print('Usage: \n ${CommandLineParser.getUsage()}');
+      exit(0);
     }
     await AtCli.getInstance().init(currentAtSign, preferences);
-    var result;
+    dynamic result;
     // If a verb is provided, call execute method with arguments
     // Else if command is provided as argument, we'll execute command directly.
     if (parsedArgs['verb'] != null) {
@@ -50,11 +47,9 @@ void main(List<String> arguments) async {
 }
 
 String _getCurrentAtSign(ArgResults arguments) {
-  return (arguments != null)
-      ? ((arguments['atsign'] != null)
-          ? arguments['atsign']
-          : ConfigUtil.getYaml()!['auth']['at_sign'])
-      : ConfigUtil.getYaml()!['auth']['at_sign'];
+  return ((arguments['atsign'] != null)
+      ? arguments['atsign']
+      : ConfigUtil.getYaml()!['auth']['at_sign']);
 }
 
 String getCommand(ArgResults arguments) {
@@ -70,17 +65,13 @@ Future<AtCliPreference> _getAtCliPreference(ArgResults? parsedArgs) async {
 
   preferences.authRequired = parsedArgs!['auth'];
 
-  preferences.authMode = (parsedArgs != null)
-      ? ((parsedArgs['mode'] != null)
-          ? parsedArgs['mode']
-          : ConfigUtil.getYaml()!['auth']['mode'])
-      : ConfigUtil.getYaml()!['auth']['mode'];
+  preferences.authMode = ((parsedArgs['mode'] != null)
+      ? parsedArgs['mode']
+      : ConfigUtil.getYaml()!['auth']['mode']);
 
-  preferences.authKeyFile = (parsedArgs != null)
-      ? ((parsedArgs['authKeyFile'] != null)
-          ? parsedArgs['authKeyFile']
-          : ConfigUtil.getYaml()!['auth']['key_file_location'])
-      : ConfigUtil.getYaml()!['auth']['key_file_location'];
+  preferences.authKeyFile = ((parsedArgs['authKeyFile'] != null)
+      ? parsedArgs['authKeyFile']
+      : ConfigUtil.getYaml()!['auth']['key_file_location']);
 
   return preferences;
 }

--- a/packages/at_cli/lib/src/at_cli.dart
+++ b/packages/at_cli/lib/src/at_cli.dart
@@ -17,14 +17,14 @@ class AtCli {
     return _singleton;
   }
 
-  var _atSign;
+  late String _atSign;
 
-  var _aesEncryptionKey;
-  var _pkamPrivateKey;
+  late String _aesEncryptionKey;
+  late String _pkamPrivateKey;
 
-  var _atClientImpl;
+  AtClient? _atClientImpl;
 
-  /// Method to create Atlookup instance with the preferences
+  /// Method to create AtLookup instance with the preferences
   Future<void> init(
       String currentAtSign, AtCliPreference atCliPreference) async {
     _atSign = currentAtSign;
@@ -37,10 +37,11 @@ class AtCli {
     var atClientPreference =
         _getAtClientPreference(_pkamPrivateKey, atCliPreference);
 
-    await AtClientImpl.createClient(
+    AtClientManager atClientManager = AtClientManager.getInstance();
+    await atClientManager.setCurrentAtSign(
         _atSign, atCliPreference.namespace, atClientPreference);
 
-    _atClientImpl = await AtClientImpl.getClient(_atSign);
+    _atClientImpl = atClientManager.atClient;
     if (_atClientImpl == null) {
       throw Exception('unable to create at client instance');
     }
@@ -53,7 +54,7 @@ class AtCli {
       AtCliPreference atCliPreference, ArgResults arguments) async {
     var verb = arguments['verb'];
     bool auth = arguments['auth'];
-    var result;
+    dynamic result;
     try {
       switch (verb) {
         case 'update':
@@ -165,7 +166,7 @@ class AtCli {
   Future<String> executeCommand(
       String currentAtSign, AtCliPreference atCliPreference, String command,
       {bool isAuth = false}) async {
-    var result;
+    dynamic result;
     try {
       command = command + '\n';
       if (isAuth) {

--- a/packages/at_cli/lib/src/command_line_parser.dart
+++ b/packages/at_cli/lib/src/command_line_parser.dart
@@ -7,7 +7,7 @@ class CommandLineParser {
   /// flags and options defined by this parser, and returns the result.
   static var parser = ArgParser();
   static ArgResults? getParserResults(List<String> arguments) {
-    var results;
+    ArgResults? results;
     // var parser = ArgParser();
     parser.addFlag('auth',
         help: 'Set this flag if command needs auth to server',
@@ -38,7 +38,7 @@ class CommandLineParser {
     parser.addOption('regex', abbr: 'r', help: 'regex for scan');
 
     try {
-      if (arguments != null && arguments.isNotEmpty) {
+      if (arguments.isNotEmpty) {
         results = parser.parse(arguments);
       }
       return results;

--- a/packages/at_cli/pubspec.yaml
+++ b/packages/at_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_cli
 description: A command line utility for at protocol commands.
-version: 3.0.0
+version: 3.1.0
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 
@@ -8,12 +8,12 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  args: ^2.1.1
-  at_lookup: ^3.0.7
-  at_client: ^3.0.9
-  crypton: ^2.0.1
-  encrypt: ^5.0.0
-  yaml_writer: ^1.0.2
+  args: ^2.4.0
+  at_lookup: ^3.0.35
+  at_client: ^3.0.56
+  crypton: ^2.1.0
+  encrypt: ^5.0.1
+  yaml_writer: ^1.0.3
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.41
+- fix: Add 'configkey' to list of reserved keys for key validation purposes
 ## 3.0.40
 - fix: Add notification expiry to the notify verb builder.
 ## 3.0.39

--- a/packages/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/packages/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -9,7 +9,13 @@ abstract class Regexes {
   static const allowedEmoji =
       r'''((\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))''';
   static const _charsInReservedKey =
-      r'(shared_key|publickey|privatekey|self_encryption_key|commitLogCompactionStats|accessLogCompactionStats|notificationCompactionStats|signing_privatekey|signing_publickey|signing_keypair_generated|at_pkam_privatekey|at_pkam_publickey|at_secret_deleted|at_secret|_[\w-]+|)';
+      r'(shared_key|publickey|privatekey|self_encryption_key'
+      r'|commitLogCompactionStats|accessLogCompactionStats'
+      r'|notificationCompactionStats|signing_privatekey|signing_publickey'
+      r'|signing_keypair_generated|at_pkam_privatekey|at_pkam_publickey'
+      r'|at_secret_deleted|at_secret'
+      r'|configkey'
+      r'|_[\w-]+|)';
 
   static const String namespaceFragment =
       '''\\.(?<namespace>$charsInNamespace)''';

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.40
+version: 3.0.41
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/at_key_type_test.dart
+++ b/packages/at_commons/test/at_key_type_test.dart
@@ -130,5 +130,10 @@ void main() {
       var keyType = AtKey.getKeyType('privatekey:at_secret');
       expect(keyType, equals(KeyType.reservedKey));
     });
+
+    test('Test reserved key type for config key (blocklist/allowlist)', () {
+      var keyType = AtKey.getKeyType('configkey');
+      expect(keyType, equals(KeyType.reservedKey));
+    });
   });
 }

--- a/packages/at_commons/test/notify_verb_builder_test.dart
+++ b/packages/at_commons/test/notify_verb_builder_test.dart
@@ -59,7 +59,7 @@ void main() {
         ..sharedWith = 'bob'
         ..pubKeyChecksum = '123'
         ..sharedKeyEncrypted = 'abc'
-      ..ttln = 100;
+        ..ttln = 100;
       var command = notifyVerbBuilder.buildCommand();
       expect(command,
           'notify:id:123:notifier:SYSTEM:ttln:100:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');


### PR DESCRIPTION
**What I did**
- test: Added a test for 'configkey' to be recognised as a reserved key
- fix: Add 'configkey' to list of reserved keys for key validation purposes
- chore: Ran dart format
