### PR TITLE
feat: Tightened the validation of 'public' key names. 

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.42
+- fix: Tightened the validation of 'public' key names. Keys like this: `public:@bob:foo.bar@alice` will now correctly be identified as not being valid.
 ## 3.0.41
 - fix: Add 'configkey' to list of reserved keys for key validation purposes
 ## 3.0.40

--- a/packages/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/packages/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -22,22 +22,22 @@ abstract class Regexes {
   static const String ownershipFragment =
       '''@(?<owner>($charsInAtSign|$allowedEmoji){1,55})''';
   static const String sharedWithFragment =
-      '''(?<sharedWith>($charsInAtSign|$allowedEmoji){1,55}):)''';
+      '''((?<sharedWith>($charsInAtSign|$allowedEmoji){1,55}):)''';
   static const String entityFragment =
       '''(?<entity>($charsInEntity|$allowedEmoji)+)''';
 
   static const String publicKeyStartFragment =
-      '''(?<visibility>(public:){1})((@$sharedWithFragment)?$entityFragment''';
+      '''(?<visibility>(public:){1})$entityFragment''';
   static const String privateKeyStartFragment =
-      '''(?<visibility>(private:){1})((@$sharedWithFragment)?$entityFragment''';
+      '''(?<visibility>(private:){1})(@$sharedWithFragment)?$entityFragment''';
   static const String selfKeyStartFragment =
-      '''((@$sharedWithFragment)?(_*$entityFragment)''';
+      '''(@$sharedWithFragment)?(_*$entityFragment)''';
   static const String sharedKeyStartFragment =
-      '''((@$sharedWithFragment)(_*$entityFragment)''';
+      '''(@$sharedWithFragment)(_*$entityFragment)''';
   static const String cachedSharedKeyStartFragment =
-      '''((cached:)(@$sharedWithFragment)(_*$entityFragment)''';
+      '''(cached:)(@$sharedWithFragment)(_*$entityFragment)''';
   static const String cachedPublicKeyStartFragment =
-      '''(?<visibility>(cached:public:){1})((@$sharedWithFragment)?$entityFragment''';
+      '''(?<visibility>(cached:public:){1})$entityFragment''';
   static const String reservedKeyFragment =
       '''(((@(?<sharedWith>($charsInAtSign|$allowedEmoji){1,55}))|public|privatekey):)?(?<atKey>$_charsInReservedKey)(@(?<owner>($charsInAtSign|$allowedEmoji){1,55}))?''';
   static const String localKeyFragment =
@@ -122,7 +122,7 @@ class RegexesNonMandatoryNamespace implements Regexes {
       '''${Regexes.cachedSharedKeyStartFragment}${Regexes.ownershipFragment}''';
   static const String _cachedPublicKey =
       '''${Regexes.cachedPublicKeyStartFragment}${Regexes.ownershipFragment}''';
-  static const String _localkey =
+  static const String _localKey =
       '''${Regexes.localKeyFragment}${Regexes.ownershipFragment}''';
 
   @override
@@ -147,7 +147,7 @@ class RegexesNonMandatoryNamespace implements Regexes {
   String get reservedKey => Regexes.reservedKeyFragment;
 
   @override
-  String get localKey => _localkey;
+  String get localKey => _localKey;
 }
 
 class RegexUtil {

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.41
+version: 3.0.42
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/at_key_regex_test.dart
+++ b/packages/at_commons/test/at_key_regex_test.dart
@@ -8,11 +8,10 @@ void main() {
   group('A group of tests to validate keyType', () {
     test('Tests to validate public key type, namespace mandatory', () {
       var keyTypeList = [];
-      keyTypeList.add('public:@bob:phone.buzz@bob');
       keyTypeList.add('public:phone.buzz@bob');
-      keyTypeList.add('public:@bob:p.b@bob');
+      keyTypeList.add('public:p.b@bob');
       keyTypeList.add('public:pho_-ne.b@bob');
-      keyTypeList.add('public:@bob💙:phone😀.buzz@bob💙');
+      keyTypeList.add('public:phone😀.buzz@bob💙');
       keyTypeList.add('public:phone.me@bob');
 
       for (var key in keyTypeList) {
@@ -23,20 +22,20 @@ void main() {
 
     test('Tests to validate public key type, namespace not mandatory', () {
       var keyTypeList = [];
-      keyTypeList.add('public:@bob:phone.buzz@bob');
-      keyTypeList.add('public:@bob:phone@bob');
+      keyTypeList.add('public:phone.buzz@bob');
+      keyTypeList.add('public:phone@bob');
 
       keyTypeList.add('public:phone.buzz@bob');
       keyTypeList.add('public:phone@bob');
 
-      keyTypeList.add('public:@bob:p.b@bob');
-      keyTypeList.add('public:@bob:p@bob');
+      keyTypeList.add('public:p.b@bob');
+      keyTypeList.add('public:p@bob');
 
       keyTypeList.add('public:pho_-ne.b@bob');
       keyTypeList.add('public:pho_-ne@bob');
 
-      keyTypeList.add('public:@bob💙:phone😀.buzz@bob💙');
-      keyTypeList.add('public:@bob💙:phone😀@bob💙');
+      keyTypeList.add('public:phone😀.buzz@bob💙');
+      keyTypeList.add('public:phone😀@bob💙');
 
       keyTypeList.add('public:phone.me@bob');
       keyTypeList.add('public:phone@bob');
@@ -160,11 +159,10 @@ void main() {
 
     test('Tests to validate cached public keys, namespace mandatory', () {
       var keyTypeList = [];
-      keyTypeList.add("cached:public:@jagannadh:phone.buzz@jagannadh");
       keyTypeList.add("cached:public:phone.buzz@jagannadh");
       keyTypeList.add("cached:public:p.b@jagannadh");
       keyTypeList.add("cached:public:pho_-n________e.b@jagannadh");
-      keyTypeList.add("cached:public:@jagannadh💙:phone😀.buzz@jagannadh💙");
+      keyTypeList.add("cached:public:phone😀.buzz@jagannadh💙");
 
       for (var key in keyTypeList) {
         var type = RegexUtil.keyType(key, true);
@@ -174,9 +172,6 @@ void main() {
 
     test('Tests to validate cached public keys, namespace not mandatory', () {
       var keyTypeList = [];
-      keyTypeList.add("cached:public:@jagannadh:phone.buzz@jagannadh");
-      keyTypeList.add("cached:public:@jagannadh:phone@jagannadh");
-
       keyTypeList.add("cached:public:phone.buzz@jagannadh");
       keyTypeList.add("cached:public:phone@jagannadh");
 
@@ -186,8 +181,8 @@ void main() {
       keyTypeList.add("cached:public:pho_-n________e.b@jagannadh");
       keyTypeList.add("cached:public:pho_-n________e@jagannadh");
 
-      keyTypeList.add("cached:public:@jagannadh💙:phone😀.buzz@jagannadh💙");
-      keyTypeList.add("cached:public:@jagannadh💙:phone😀@jagannadh💙");
+      keyTypeList.add("cached:public:phone😀.buzz@jagannadh💙");
+      keyTypeList.add("cached:public:phone😀@jagannadh💙");
 
       for (var key in keyTypeList) {
         var type = RegexUtil.keyType(key, false);

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -632,7 +632,7 @@ void main() {
   group('A group of tests to validate the cached public keys', () {
     test('validate a cached public key with namespace', () {
       var validationResult = AtKeyValidators.get().validate(
-          'cached:public:@bob:phone.me@alice',
+          'cached:public:phone.me@alice',
           ValidationContext()..atSign = '@bob');
       expect(validationResult.isValid, true);
     });

--- a/packages/at_commons/test/at_key_type_test.dart
+++ b/packages/at_commons/test/at_key_type_test.dart
@@ -64,12 +64,24 @@ void main() {
       var keyType = AtKey.getKeyType('phone@bob', enforceNameSpace: true);
       expect(keyType, equals(KeyType.invalidKey));
     });
+
     test('Test self key type with atsign and without namespace', () {
       var keyType = AtKey.getKeyType('@bob:phone@bob', enforceNameSpace: true);
       expect(keyType, equals(KeyType.invalidKey));
     });
+
     test('Test local key type with atsign and without namespace', () {
       var keyType = AtKey.getKeyType('local:phone@bob', enforceNameSpace: true);
+      expect(keyType, equals(KeyType.invalidKey));
+    });
+
+    test('Test malformed key cached:public:cached:public:privateaccount.wavi@dying36dragonfly', () {
+      var keyType = AtKey.getKeyType('cached:public:cached:public:privateaccount.wavi@dying36dragonfly', enforceNameSpace: false);
+      expect(keyType, equals(KeyType.invalidKey));
+    });
+
+    test('Test malformed key public:@public:image.wavi@colin', () {
+      var keyType = AtKey.getKeyType('public:@public:image.wavi@colin', enforceNameSpace: false);
       expect(keyType, equals(KeyType.invalidKey));
     });
   });

--- a/packages/at_commons/test/test_keys.dart
+++ b/packages/at_commons/test/test_keys.dart
@@ -59,34 +59,42 @@ class TestKeys {
   _initNonBobPublicKeys() {
     // public key with max of 55 characters for the @sign
     validPublicKeys.add(
-        "public:@bob0123456789012345678901234567890123456789012345:phone.buzz@bob0123456789012345678901234567890123456789012345");
+        "public:phone.buzz@bob0123456789012345678901234567890123456789012345");
     // public key with valid punctuations in the @sign
-    validPublicKeys.add("public:@jagann_a-d_h:phone.buzz@jagann_a-d_h");
+    validPublicKeys.add("public:phone.buzz@jagann_a-d_h");
     // public key with emoji's in @sign
-    validPublicKeys.add("public:@bob💙:phone.buzz@bob💙");
+    validPublicKeys.add("public:phone.buzz@bob💙");
     // Emojis in both @sign and entity
-    validPublicKeys.add("public:@bob💙:phone😀.buzz@bob💙");
+    validPublicKeys.add("public:phone😀.buzz@bob💙");
 
     // More than 55 characters for the @sign
     List<String> temp = [];
     temp.add(
-        "public:@bob0123456789012345678901234567890123456789012345extrachars:phone.buzz@bob0123456789012345678901234567890123456789012345extrachars");
+        "public:phone.buzz@bob0123456789012345678901234567890123456789012345extrachars");
     //  Invalid punctuations in the @sign
-    temp.add("public:@bo#b:phone.buzz@bo#b");
+    temp.add("public:phone.buzz@bo#b");
     //  Invalid and valid punctuations in the @sign
-    temp.add("public:@jagan_____na#dh💙:phone.buzz@bob💙");
+    temp.add("public:phone.buzz@jagan_____na#dh💙");
+    //  sharedWith as well as public (must be one or the other, can't be both)
+    temp.add("public:@bob:phone.buzz@jagan_____na#dh💙");
+    //  more than one colon after 'public'
+    temp.add("public::phone.buzz@jagan_____na#dh💙");
+    //  colon in the entity fragment
+    temp.add("public::foo.b:ar.buzz@jagan_____na#dh💙");
+    //  colon before sharedBy
+    temp.add("public:phone.buzz:@jagan_____na#dh💙");
+    //  colon in sharedBy
+    temp.add("public:phone.buzz@jag:an_____na#dh💙");
+    //  colon at end of sharedBy
+    temp.add("public:phone.buzz@jagan_____na#dh💙:");
 
     invalidPublicKeysNamespaceMandatory.addAll(temp);
     invalidPublicKeysNamespaceOptional.addAll(temp);
   }
 
   _initValidPublicKeys() {
-    // public key with sharedWith specified
-    validPublicKeys.add("public:@bob:phone.buzz@bob");
-    //  public key with sharedWith not being specified
+    //  simple public key
     validPublicKeys.add("public:phone.buzz@bob");
-    //  public key with sharedWith specified and single character entity and namespace
-    validPublicKeys.add("public:@bob:p.b@bob");
     //  public key with single character entity and namespace
     validPublicKeys.add("public:p.b@bob");
     //  public key with punctuations in the entity name
@@ -98,13 +106,15 @@ class TestKeys {
     // public key with many punctuations in the entity name
     validPublicKeys.add("public:pho_-n________e.b@bob");
     //  public key with emoji's in entity
-    validPublicKeys.add("public:@bob:phone😀.buzz@bob");
+    validPublicKeys.add("public:phone😀.buzz@bob");
   }
 
   _initInvalidPublicKeys() {
     List<String> temp = [];
     // Misspelt public
-    temp.add("publicc:@bob:phone.buzz@bob");
+    temp.add("publicc:phone.buzz@bob");
+    //  sharedWith as well as public (must be one or the other, can't be both)
+    temp.add("public:@bob:phone.buzz@bob");
     //  No public
     temp.add("phone.buzz@bob");
     //  No public and start with a :
@@ -115,14 +125,24 @@ class TestKeys {
     temp.add("public:pho#n____-____e.b@bob");
     // Key with no atsign
     temp.add("public:pho#n____-____e.b");
+    // key without entity or owner
+    temp.add("public:");
+    // key without owner
+    temp.add("public:foo.bar");
+    // key without owner
+    temp.add("public:foo.bar@");
     // key without entity
     temp.add("public:@bob");
+    // multiple colons
+    temp.add("public::@bob");
+    // colon prefixed
+    temp.add(":public:foo.bar@bob");
 
     invalidPublicKeysNamespaceMandatory.addAll(temp);
     invalidPublicKeysNamespaceOptional.addAll(temp);
 
     //  No namespace
-    invalidPublicKeysNamespaceMandatory.add("public:@bob:phone@bob");
+    invalidPublicKeysNamespaceMandatory.add("public:phone@bob");
   }
 
   _initNonBobPrivateKeys() {
@@ -189,29 +209,28 @@ class TestKeys {
   _initNonBobCachedPublicKeys() {
     // cached public key with max of 55 characters for the @sign
     validCachedPublicKeys.add(
-        "cached:public:@bob0123456789012345678901234567890123456789012345:phone.buzz@bob0123456789012345678901234567890123456789012345");
+        "cached:public:phone.buzz@bob0123456789012345678901234567890123456789012345");
     //  cached public key with valid punctuations in the @sign
     validCachedPublicKeys
-        .add("cached:public:@jagann_a-d_h:phone.buzz@jagann_a-d_h");
+        .add("cached:public:phone.buzz@jagann_a-d_h");
     //  cached public key with emoji's in @sign
-    validCachedPublicKeys.add("cached:public:@bob💙:phone.buzz@bob💙");
+    validCachedPublicKeys.add("cached:public:phone.buzz@bob💙");
     // cached public public in both @sign and entity
-    validCachedPublicKeys.add("cached:public:@bob💙:phone😀.buzz@bob💙");
+    validCachedPublicKeys.add("cached:public:phone😀.buzz@bob💙");
+
     List<String> temp = [];
     //  Invalid and valid punctuations in the @sign
-    temp.add("cached:public:@jagan_____na#dh💙:phone.buzz@bob💙");
+    temp.add("cached:public:phone.buzz@jagan_____na#dh💙");
 
     invalidCachedPublicKeysNamespaceMandatory.addAll(temp);
     invalidCachedPublicKeysNamespaceOptional.addAll(temp);
   }
 
   _initValidCachedPublicKeys() {
-    // cached public key with sharedWith specified
-    validCachedPublicKeys.add("cached:public:@bob:phone.buzz@bob");
-    //  cached public key with sharedWith not being specified
+    // simple cached public key
     validCachedPublicKeys.add("cached:public:phone.buzz@bob");
-    //  cached public key with sharedWith specified and single character entity and namespace
-    validCachedPublicKeys.add("cached:public:@bob:p.b@bob");
+    //  cached public key with single character entity and namespace
+    validCachedPublicKeys.add("cached:public:p.b@bob");
     //  cached public key with single character entity and namespace
     validCachedPublicKeys.add("cached:public:p.b@bob");
     //  cached public key with punctuations in the entity name
@@ -219,13 +238,15 @@ class TestKeys {
     // cached public key with many punctuations in the entity name
     validCachedPublicKeys.add("cached:public:pho_-n________e.b@bob");
     //  cached public key with emoji's in entity
-    validCachedPublicKeys.add("cached:public:@bob:phone😀.buzz@bob");
+    validCachedPublicKeys.add("cached:public:phone😀.buzz@bob");
   }
 
   _initInvalidCachedPublicKeys() {
     List<String> temp = [];
     // Mis-spelt public
-    temp.add("cached:publicc:@bob:phone.buzz@bob");
+    temp.add("cached:publicc:phone.buzz@bob");
+    //  sharedWith as well as public (must be one or the other, can't be both)
+    temp.add("cached:public:@bob:phone.buzz@bob");
     //  No cached public
     temp.add("phone.buzz@bob");
     //  No cached public and start with a :
@@ -236,16 +257,16 @@ class TestKeys {
     temp.add("cached:public:pho#n____-____e.b@bob");
     // More than 55 characters for the @sign
     temp.add(
-        "cached:public:@bob0123456789012345678901234567890123456789012345extracharshere:phone.buzz@bob");
+        "cached:public:phone.buzz@bob0123456789012345678901234567890123456789012345extracharshere");
     //  Invalid punctuations in the @sign
-    temp.add("cached:public:@jaganna#dh:phone.buzz@bob");
+    temp.add("cached:public:phone.buzz@@jaganna#dh");
 
     invalidCachedPublicKeysNamespaceMandatory.addAll(temp);
     invalidCachedPublicKeysNamespaceOptional.addAll(temp);
 
     //  No namespace
     invalidCachedPublicKeysNamespaceMandatory
-        .add("cached:public:@bob:phone@bob");
+        .add("cached:public:phone@bob");
   }
 
   _initNonBobSelfKeys() {


### PR DESCRIPTION
**What I did**
feat: Tightened the validation of 'public' key names. Keys like this: `public:@bob:foo.bar@alice` will now correctly be identified as not being valid.

**How I did it**
- refactor: Fixed the sharedWith regex which had unbalanced ( and ) count, and removed the now-extraneous ( in the places sharedWith was being included
- fix: Remove the sharedWithFragment from the publicKeyStartFragment and cachedPublicKeyStartFragment
- test: Modified test cases so that keys like 'public:@bob:foo.bar@alice' which were previously expected to be valid are now expected to be invalid
- test: Added some additional malformed keys to the invalidKeys test
- test: Modified test_keys.dart (which sets up arrays of valid and invalid keys of various types) to reflect the tightened rules, and adding some additional malformed keys to test

**- How to verify it**
- [x] New and existing tests pass
- [x] at_client_sdk tests pass [when using this branch of at_commons](https://github.com/atsign-foundation/at_client_sdk/pull/952)

**- Description for the changelog**
feat: Tightened the validation of 'public' key names. Keys like this: `public:@bob:foo.bar@alice` will now correctly be identified as not being valid.