### PR TITLE
refactor: deprecate formatAtsign() and move logic to fixAtsign()

### DIFF
--- a/packages/at_utils/CHANGELOG.md
+++ b/packages/at_utils/CHANGELOG.md
@@ -1,7 +1,11 @@
-# 3.0.11
+## 3.0.12
+- Deprecate formatAtSign() in atsign_util
+- Moved the functionality of formatAtSign() to fixAtSign()
+- Upgrade dependency at_commons to latest version v3.0.42
+## 3.0.11
 - Change the ConsoleLoggingHandler to static reference
 - Update the at_commons version to 3.0.25
-# 3.0.10
+## 3.0.10
 - at_commons version change to 3.0.17 for AtException hierarchy and introducing new AtException subclasses
 ## 3.0.9
 - Changed at_commons dependency from 3.0.11 to ^3.0.11

--- a/packages/at_utils/CHANGELOG.md
+++ b/packages/at_utils/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 3.0.12
-- Deprecate formatAtSign() in atsign_util
-- Moved the functionality of formatAtSign() to fixAtSign()
+- Deprecate formatAtSign() in atsign_util and moved the functionality to fixAtSign()
 - Upgrade dependency at_commons to latest version v3.0.42
 ## 3.0.11
 - Change the ConsoleLoggingHandler to static reference

--- a/packages/at_utils/lib/src/atsign_util.dart
+++ b/packages/at_utils/lib/src/atsign_util.dart
@@ -74,7 +74,7 @@ class AtUtils {
   }
 
   /// Return AtSign by appending '@' at the beginning if not present
-  @Deprecated('Use formatAtSign()')
+  @Deprecated('Use fixAtSign()')
   static String? formatAtSign(String? atSign) {
     // verify whether atSign started with '@' or not
     if ((atSign != null && atSign.isNotEmpty) && !atSign.startsWith('@')) {

--- a/packages/at_utils/lib/src/atsign_util.dart
+++ b/packages/at_utils/lib/src/atsign_util.dart
@@ -23,12 +23,13 @@ class AtUtils {
   /// Apply all the rules on the provided atSign and return fixedAtSign
   static String fixAtSign(String atSign) {
     // @signs are always lowercase Latin
-    if (atSign == '') {
+    if (atSign == '' || atSign.isEmpty) {
       throw InvalidAtSignException(AtMessage.noAtSign.text);
     }
     atSign = atSign.toLowerCase();
-    if (atSign.contains('@') == false) {
-      throw InvalidAtSignException(AtMessage.noAtSign.text);
+    // if atsign does not start with '@' prepend an '@'
+    if (!atSign.startsWith('@')) {
+      atSign = '@$atSign';
     }
     // @signs can only have one @ character in them
     var noAT = atSign.replaceFirst('@', '');
@@ -36,7 +37,7 @@ class AtUtils {
       throw InvalidAtSignException(AtMessage.moreThanOneAt.text);
     }
     // The dot "." can be used in an @sign but it is removed so @colinconstable is the same as @colin.constable
-    // As is home.phone@colin stays home.phone@colin
+    // home.phone@colin stays home.phone@colin
     // but home.phone@colin.constable gets translated to home.phone@colinconstable
     // This is for clarity for humans
     var split = atSign.split('@');
@@ -73,6 +74,7 @@ class AtUtils {
   }
 
   /// Return AtSign by appending '@' at the beginning if not present
+  @Deprecated('Use formatAtSign()')
   static String? formatAtSign(String? atSign) {
     // verify whether atSign started with '@' or not
     if ((atSign != null && atSign.isNotEmpty) && !atSign.startsWith('@')) {

--- a/packages/at_utils/pubspec.yaml
+++ b/packages/at_utils/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_utils
 description: A Dart library that contains various utility classes such as atSign, atmetadata, configuration, and logger.
-version: 3.0.11
+version: 3.0.12
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 documentation: https://docs.atsign.com/
@@ -13,7 +13,7 @@ dependencies:
   logging: ^1.0.1
   yaml: ^3.1.0
   crypto: ^3.0.1
-  at_commons: ^3.0.25
+  at_commons: ^3.0.42
   collection: ^1.15.0
 
 dev_dependencies:

--- a/packages/at_utils/test/fix_at_sign_test.dart
+++ b/packages/at_utils/test/fix_at_sign_test.dart
@@ -6,15 +6,21 @@ import 'package:test/test.dart';
 void main() {
   group('A group of positive atsign tests', () {
     test('atsign in upper case', () {
-      var atSign = 'PHONE@BOB';
+      var atSign = '@BOB';
       atSign = AtUtils.fixAtSign(atSign);
-      expect(atSign, 'phone@bob');
+      expect(atSign, '@bob');
     });
 
     test('atsign contains .', () {
-      var atSign = 'home.phone@colin.constable';
+      var atSign = '@colin.constable';
       atSign = AtUtils.fixAtSign(atSign);
-      expect(atSign, 'home.phone@colinconstable');
+      expect(atSign, '@colinconstable');
+    });
+
+    test('@ is prepended when atsign does not start with @', () {
+      var atsign = 'randomFlex';
+      atsign = AtUtils.fixAtSign(atsign);
+      expect(atsign, '@randomflex');
     });
   });
   group('A group of invalid atsign test', () {
@@ -28,18 +34,8 @@ void main() {
                   'invalid @sign: must include one @ character and at least one character on the right')));
     });
 
-    test('atsign without @ - InvalidAtSignException', () {
-      var atSign = 'bob';
-      expect(
-          () => AtUtils.fixAtSign(atSign),
-          throwsA(predicate((dynamic e) =>
-              e is InvalidAtSignException &&
-              e.message ==
-                  'invalid @sign: must include one @ character and at least one character on the right')));
-    });
-
     test('atsign with more @ - InvalidAtSignException', () {
-      var atSign = 'phone@bob@alice';
+      var atSign = '@bob@alice';
       expect(
           () => AtUtils.fixAtSign(atSign),
           throwsA(predicate((dynamic e) =>
@@ -55,11 +51,11 @@ void main() {
           throwsA(predicate((dynamic e) =>
               e is InvalidAtSignException &&
               e.message ==
-                  'invalid @sign: must include one @ character and at least one character on the right')));
+                  'invalid @sign: Cannot Contain more than one @ character')));
     });
 
     test('white spaces in atsign - InvalidAtSignException', () {
-      var atSign = 'pho ne@bob';
+      var atSign = '@b ob';
       expect(
           () => AtUtils.fixAtSign(atSign),
           throwsA(predicate((dynamic e) =>
@@ -69,7 +65,7 @@ void main() {
     });
 
     test('reserved characters in atsign : + - InvalidAtSignException', () {
-      var atSign = 'phone@\U+237E';
+      var atSign = '@\U+237E';
       expect(
           () => AtUtils.fixAtSign(atSign),
           throwsA(predicate((dynamic e) =>
@@ -79,7 +75,7 @@ void main() {
     });
 
     test('reserved characters with ascii codes - InvalidAtsignException', () {
-      var atSign = 'phone@U' + String.fromCharCode(43);
+      var atSign = '@U' + String.fromCharCode(43);
       expect(
           () => AtUtils.fixAtSign(atSign),
           throwsA(predicate((dynamic e) =>
@@ -99,7 +95,7 @@ void main() {
     });
 
     test('special characters in atsign - * InvalidAtSignException', () {
-      var atSign = 'phone^:@b*b';
+      var atSign = '@b*b';
       expect(
           () => AtUtils.fixAtSign(atSign),
           throwsA(predicate((dynamic e) =>
@@ -109,7 +105,7 @@ void main() {
     });
 
     test('control characters in atsign - InvalidAtSignException', () {
-      var atSign = 'phone@\u2400';
+      var atSign = '@\u2400';
       expect(
           () => AtUtils.fixAtSign(atSign),
           throwsA(predicate((dynamic e) =>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_tools/issues/293
**- What I did**
- deprecate formatAtsign()
- move its functionality to fixAtSign()
- fixAtSign() does not throw an exception anymore when an atsign without '@' is input
- updated tests to match current behaviour
- Tests previously assumed that atkey would be passed as input to fixAtSign() which is not accurate. Updated tests to assert/expect atsigns and verify the behaviour

**- How to verify it**
- New test case added and older tests modified in test/fix_atsign_test.dart

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
refactor: deprecate formatAtsign() and move logic to fixAtsign()