### PR TITLE
chore: prepublish cleanup

### DIFF
--- a/packages/at_cli/pubspec.yaml
+++ b/packages/at_cli/pubspec.yaml
@@ -14,8 +14,11 @@ dependencies:
   args: ^2.4.0
   at_lookup: ^3.0.35
   at_client: ^3.0.56
+  at_commons: ^3.0.45
+  at_utils: ^3.0.12
   crypton: ^2.1.0
   encrypt: ^5.0.1
+  yaml: ^3.1.1
   yaml_writer: ^1.0.3
 
 dev_dependencies:

--- a/packages/at_pkam/LICENSE
+++ b/packages/at_pkam/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, The Atsign Foundation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/at_pkam/pubspec.yaml
+++ b/packages/at_pkam/pubspec.yaml
@@ -1,7 +1,7 @@
 name: at_pkam
 description: A command-line utility to generate PKAM digest
 version: 1.1.1
-# homepage: https://www.example.com
+repository: https://github.com/atsign-foundation/at_tools
 
 executables:
   at_pkam: main
@@ -10,9 +10,11 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
+  args: ^2.4.1
+  archive: ^3.1.2
   crypton: ^2.0.1
   encrypt: ^5.0.0
-  archive: ^3.1.2
+  path: ^1.8.3
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Did the following recommendations for publishing based on warnings from `pub publish --dry-run`:

Added transitive dependencies which were actually being used as direct dependencies to the pubspec.yaml for at_pkam and at_cli.

Added a LICENSE to at_pkam.


Related to #324 
Note: Opted not to publish at_hive_recovery or at_ve_doctor since the previous author has them explicitly listed them not to be published, and they aren't really meant for regular use.

`pub global` does support installing from git if needed.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: prepublish cleanup
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->