### PR TITLE
build: Changes for Dart 3

### DIFF
--- a/packages/at_cli/pubspec.yaml
+++ b/packages/at_cli/pubspec.yaml
@@ -8,7 +8,7 @@ executables:
   at_cli: main
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   args: ^2.4.0
@@ -20,6 +20,28 @@ dependencies:
   encrypt: ^5.0.1
   yaml: ^3.1.1
   yaml_writer: ^1.0.3
+
+dependency_overrides:
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_lookup
+      ref: dart-3
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk.git
+      path: packages/at_client
+      ref: dart-3
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_utils:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_cli/pubspec.yaml
+++ b/packages/at_cli/pubspec.yaml
@@ -40,7 +40,7 @@ dependency_overrides:
   at_utils:
     git:
       url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
+      path: packages/at_utils
       ref: dart-3
 
 dev_dependencies:

--- a/packages/at_cli/pubspec.yaml
+++ b/packages/at_cli/pubspec.yaml
@@ -21,28 +21,6 @@ dependencies:
   yaml: ^3.1.1
   yaml_writer: ^1.0.3
 
-dependency_overrides:
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_lookup
-      ref: dart-3
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk.git
-      path: packages/at_client
-      ref: dart-3
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: dart-3
-  at_utils:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_utils
-      ref: dart-3
-
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.0

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
   uuid: ^3.0.6

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   uuid: ^3.0.6

--- a/packages/at_cram/pubspec.yaml
+++ b/packages/at_cram/pubspec.yaml
@@ -3,7 +3,7 @@ description: A command-line utility to generate CRAM digest
 version: 1.1.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 #dependencies:
 #  path: ^1.7.0

--- a/packages/at_dump_atKeys/pubspec.yaml
+++ b/packages/at_dump_atKeys/pubspec.yaml
@@ -3,7 +3,7 @@ description: A command-line utility to dump keys from an atKeys file
 version: 1.0.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependency_overrides:
   at_pkam:

--- a/packages/at_hive_recovery/pubspec.yaml
+++ b/packages/at_hive_recovery/pubspec.yaml
@@ -13,13 +13,5 @@ dependencies:
   at_persistence_secondary_server: ^3.0.5
   crypto: ^3.0.1
 
-dependency_overrides:
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      path: packages/at_persistence_secondary_server
-      ref: dart-3
-
-
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_hive_recovery/pubspec.yaml
+++ b/packages/at_hive_recovery/pubspec.yaml
@@ -7,18 +7,18 @@ executables:
   at_hive_recovery: main
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   at_persistence_secondary_server: ^3.0.5
   crypto: ^3.0.1
 
 dependency_overrides:
-  hive:
+  at_persistence_secondary_server:
     git:
-      url: https://github.com/atsign-foundation/hive.git
-      path: hive
-      ref: corrupt_box_workaround
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_secondary_server
+      ref: dart-3
 
 
 dev_dependencies:

--- a/packages/at_pkam/pubspec.yaml
+++ b/packages/at_pkam/pubspec.yaml
@@ -7,7 +7,7 @@ executables:
   at_pkam: main
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   args: ^2.4.1

--- a/packages/at_utils/pubspec.yaml
+++ b/packages/at_utils/pubspec.yaml
@@ -7,7 +7,7 @@ documentation: https://docs.atsign.com/
 
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   logging: ^1.0.1
@@ -15,6 +15,13 @@ dependencies:
   crypto: ^3.0.1
   at_commons: ^3.0.42
   collection: ^1.15.0
+
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_utils/pubspec.yaml
+++ b/packages/at_utils/pubspec.yaml
@@ -16,13 +16,6 @@ dependencies:
   at_commons: ^3.0.42
   collection: ^1.15.0
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: dart-3
-
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.0

--- a/packages/at_ve_doctor/pubspec.yaml
+++ b/packages/at_ve_doctor/pubspec.yaml
@@ -11,15 +11,7 @@ environment:
   sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
-  at_server_status:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_server_status
-      ref: dart-3
-
-#dependency_overrides:
-#  at_server_status:
-#    path: ../../at_libraries/at_server_status
+  at_server_status: ^1.0.3
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_ve_doctor/pubspec.yaml
+++ b/packages/at_ve_doctor/pubspec.yaml
@@ -8,15 +8,14 @@ executables:
   at_ve_doctor: at_ve_doctor
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   at_server_status:
     git:
       url: https://github.com/atsign-foundation/at_libraries.git
-      path: at_server_status
-      ref: null_safety
-      version: 0.2.0
+      path: packages/at_server_status
+      ref: dart-3
 
 #dependency_overrides:
 #  at_server_status:


### PR DESCRIPTION
**- What I did**
**Note:** No changes to code; none of the packages here need to be republished
build: Modify max dart version in pubspecs to <4.0.0
build: update minimum dart SDK version to 2.15.0 in order to pick up the `unawaited` function
