### PR TITLE
fix: Add variation selector to the allowed emoji list

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.46
+- fix: Modify emoji list to allow variation selector Unicode
 ## 3.0.45
 - fix: Add constants for AtClientParticulars
 ## 3.0.44

--- a/packages/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/packages/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -7,7 +7,7 @@ abstract class Regexes {
   static const charsInAtSign = r'[\w\-_]';
   static const charsInEntity = r'''[\w\.\-_'*"]''';
   static const allowedEmoji =
-      r'''((\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))''';
+      r'''((\u00a9|\u00ae|[\u2000-\u3300]|[\ufe00-\ufe0f]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))''';
   static const _charsInReservedKey =
       r'(shared_key|publickey|privatekey|self_encryption_key'
       r'|commitLogCompactionStats|accessLogCompactionStats'

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.45
+version: 3.0.46
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/at_key_regex_test.dart
+++ b/packages/at_commons/test/at_key_regex_test.dart
@@ -225,6 +225,18 @@ void main() {
         expect(type == KeyType.cachedSharedKey, true);
       }
     });
+
+    test('A test to validate reserved key type', () {
+      var keyTypeList = [];
+
+      keyTypeList.add('public:signing_publickey@alice');
+      keyTypeList.add('public:signing_publickey@☎️_0002');
+
+      for (var key in keyTypeList) {
+        var type = RegexUtil.keyType(key, false);
+        expect(type == KeyType.reservedKey, true);
+      }
+    });
   });
 
   group('Public or private key regex match tests', () {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The secondary server fails to start for the following atSign @☎️_0002. 

Root Cause of Issue:
 - The atSign has two uni-codes 
    1. The Unicode for the emoji - U+260E
    2. The Variation Selector - U+FE0F. which represents the colour of an emoji (in this case).
In the allowed emoji list the variation selector unicode is not listed and therefore the atSign is not being matched by the regex resulting in an invalid key.

**- How I did it**
* The fix here is to add the variation selector emoji Unicode to the allowedEmoji regex.

**- How to verify it**
* Added a unit test to assert on the emoji with variation selector matching regex

**- Description for the changelog**
* Fix: Add variation selector Unicode to the emoji list.

Testing Notes:

* With the changes, able to start the "@☎️_0002" secondary server successfully locally.

```
INFO|2023-05-17 18:26:04.055315|AtSecondaryServer|Secondary server started on version : 3.0.31 on root server : vip.ve.atsign.zone 

INFO|2023-05-17 18:26:04.055381|AtSecondaryServer|Secure Socket open for @☎️_0002 ! 

FINER|2023-05-17 18:26:04.055646|AtSecondaryServer|serverSocket _listen : SecureServerSocket 
```
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->