### PR TITLE
feat: enroll verb syntax and builder

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.45
+- feat: Add syntax and verb builder for APKAM enroll verb
 ## 3.0.44
 - feat: introduce enum for pkam authentication mode
 ## 3.0.43

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -23,9 +23,8 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
     StringBuffer sb = StringBuffer();
     sb.write('enroll:');
 
-    if (operation != null) {
-      sb.write(getEnrollOperation(operation));
-    }
+    sb.write(getEnrollOperation(operation));
+
     if (appName != null) {
       sb.write(':appName:$appName');
     }

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -1,0 +1,54 @@
+import 'package:at_commons/src/verb/abstract_verb_builder.dart';
+
+import 'operation_enum.dart';
+
+/// Enroll verb builder generates enroll verb command for APKAM(Application PKAM) authentication process.
+class EnrollVerbBuilder extends AbstractVerbBuilder {
+  /// Operation type of the enroll verb - request/approve/deny. Default value will be request
+  EnrollOperationEnum operation = EnrollOperationEnum.request;
+
+  /// Name of the mobile application or client sending the enroll verb.
+  String? appName;
+
+  /// Name of the device sending the enroll verb.
+  String? deviceName;
+
+  /// Public key of an asymmetric key pair generated on the app or client.
+  String? apkamPublicKey;
+
+  List<String> namespaces = [];
+
+  @override
+  String buildCommand() {
+    StringBuffer sb = StringBuffer();
+    sb.write('enroll:');
+
+    if (operation != null) {
+      sb.write(getEnrollOperation(operation));
+    }
+    if (appName != null) {
+      sb.write(':appName:$appName');
+    }
+    if (deviceName != null) {
+      sb.write(':deviceName:$deviceName');
+    }
+    if (namespaces.isNotEmpty) {
+      sb.write(':namespaces:${namespaces.join(';')}');
+    }
+    if (apkamPublicKey != null) {
+      sb.write(':apkamPublicKey:$apkamPublicKey');
+    }
+
+    sb.write('\n');
+
+    return sb.toString();
+  }
+
+  @override
+  bool checkParams() {
+    return appName != null &&
+        deviceName != null &&
+        namespaces.isNotEmpty &&
+        apkamPublicKey != null;
+  }
+}

--- a/packages/at_commons/lib/src/verb/operation_enum.dart
+++ b/packages/at_commons/lib/src/verb/operation_enum.dart
@@ -16,3 +16,8 @@ enum MessageTypeEnum { key, text }
 
 String getMessageType(MessageTypeEnum? messageTypeEnum) =>
     '$messageTypeEnum'.split('.').last;
+
+enum EnrollOperationEnum { request, approve, deny }
+
+String getEnrollOperation(EnrollOperationEnum? enrollOperationEnum) =>
+    '$enrollOperationEnum'.split('.').last;

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -125,4 +125,6 @@ class VerbSyntax {
   static const info = r'^info(:brief)?$';
   static const noOp = r'^noop:(?<delayMillis>\d+)$';
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
+  static const enroll =
+      r'^enroll:(?<operation>request|approve|deny)(:appName:(?<appName>(\w+)))(:deviceName:(?<deviceName>(\w+)))(:namespaces:(?<namespaces>(.*(?:;.*)*)))(:apkamPublicKey:(?<apkamPublicKey>.*))$';
 }

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.44
+version: 3.0.45
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/enroll_verb_builder_test.dart
+++ b/packages/at_commons/test/enroll_verb_builder_test.dart
@@ -1,0 +1,85 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:at_commons/src/verb/enroll_verb_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of enroll verb builder tests', () {
+    test('enroll verb - check enroll request build command', () {
+      var enrollVerbBuilder = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.request
+        ..appName = 'wavi'
+        ..deviceName = 'pixel'
+        ..namespaces = ['wavi,rw', '__manage,r']
+        ..apkamPublicKey = 'abcd1234';
+      var command = enrollVerbBuilder.buildCommand();
+      expect(command,
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:wavi,rw;__manage,r:apkamPublicKey:abcd1234\n');
+    });
+    test('enroll verb - check enroll approve build command', () {
+      var enrollVerbBuilder = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.approve
+        ..appName = 'wavi'
+        ..deviceName = 'pixel'
+        ..namespaces = ['wavi,rw']
+        ..apkamPublicKey = 'abcd1234';
+      var command = enrollVerbBuilder.buildCommand();
+      expect(command,
+          'enroll:approve:appName:wavi:deviceName:pixel:namespaces:wavi,rw:apkamPublicKey:abcd1234\n');
+    });
+    test('enroll verb - check enroll deny build command', () {
+      var enrollVerbBuilder = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.approve
+        ..appName = 'wavi'
+        ..deviceName = 'pixel'
+        ..namespaces = ['wavi,rw', '__manage,r']
+        ..apkamPublicKey = 'abcd1234';
+      var command = enrollVerbBuilder.buildCommand();
+      expect(command,
+          'enroll:approve:appName:wavi:deviceName:pixel:namespaces:wavi,rw;__manage,r:apkamPublicKey:abcd1234\n');
+    });
+
+    test('enroll verb - check enroll request verb params', () {
+      var enrollVerbBuilder = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.request
+        ..appName = 'wavi'
+        ..deviceName = 'pixel'
+        ..namespaces = ['wavi,rw', '__manage,r']
+        ..apkamPublicKey = 'abcd1234';
+
+      var command = enrollVerbBuilder.buildCommand();
+      var params = VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim())!;
+      expect(params['operation'], 'request');
+      expect(params['appName'], 'wavi');
+      expect(params['deviceName'], 'pixel');
+      expect(params['namespaces'], 'wavi,rw;__manage,r');
+      expect(params['apkamPublicKey'], 'abcd1234');
+    });
+
+    test('enroll verb - invalid syntax - no app name', () {
+      var command =
+          'enroll:request:deviceName:pixel:namespaces:wavi,rw;__manage,r:apkamPublicKey:abcd1234';
+      var params = VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim());
+      expect(params, null);
+    });
+
+    test('enroll verb - invalid syntax - no device name', () {
+      var command =
+          'enroll:request:appName:wavi:namespaces:wavi,rw;__manage,r:apkamPublicKey:abcd1234';
+      var params = VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim());
+      expect(params, null);
+    });
+
+    test('enroll verb - invalid syntax - no namespace', () {
+      var command =
+          'enroll:request:appName:wavi:deviceName:pixel:apkamPublicKey:abcd1234';
+      var params = VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim());
+      expect(params, null);
+    });
+    test('enroll verb - invalid syntax - no apkam public key', () {
+      var command =
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:wavi,r;_manage';
+      var params = VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim());
+      expect(params, null);
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**
- Added verb syntax for APKAM enroll 
- Added enroll verb builder
**- How I did it**
- added regex for enroll verb in syntax.dart
- introduced EnrollOperationEnum for enrollment type
- implemented enroll_verb_builder.dart which accepts type of enrollment(request/approve/deny), application name, device name and apkam public key
- added unit test enroll_verb_builder_test.dart

**- How to verify it**
- run the unit test enroll_verb_builder_test.dart
