### PR TITLE
fix: migrate melos to 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ doc/api/
 *.ipr
 *.iws
 *.idea/
+
+pubspec_overrides.yaml #melos


### PR DESCRIPTION
**- What I did**
added pubspec_overrides.yaml to gitignore
**- How I did it**

**- How to verify it**

**- Description for the changelog**
 migrate melos from 2.0 to 3.0