### PR TITLE
docs: Updated expected location of atKeys to use UNIX path format

### DIFF
--- a/packages/at_repl/README.md
+++ b/packages/at_repl/README.md
@@ -7,7 +7,7 @@
 A CLI application that talks directly to the atPlatform.
 
 ## Getting Started 
-Ensure you have you atSign keys, keys are usually located in "homeDirectory\.atsign\keys".
+Ensure you have your atSign keys. Keys are usually located in `$HOME/.atsign/keys`.
 
 If you don't have an atSign, visit here https://my.atsign.com/login. 
 


### PR DESCRIPTION
**- Description for the changelog**
 Updated expected location of atKeys to use UNIX path format and added missing slash.