### PR TITLE
feat: totp support in enroll

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.48
+- feat: totp support in enroll verb
 ## 3.0.47
 - fix: Enhance stats verb to allow regex for stats:15
 - feat: Add syntax and verb builder for APKAM enroll verb

--- a/packages/at_commons/lib/src/at_constants.dart
+++ b/packages/at_commons/lib/src/at_constants.dart
@@ -87,3 +87,4 @@ const String CLIENT_ID = 'clientId';
 const String APP_NAME = 'appName';
 const String APP_VERSION = 'appVersion';
 const String PLATFORM = 'platform';
+const String enrollApprovalId = 'enrollApprovalId';

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -16,6 +16,9 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
   /// Public key of an asymmetric key pair generated on the app or client.
   String? apkamPublicKey;
 
+  /// totp for the enroll request. totp must be fetched from an already enrolled app.
+  int? totp;
+
   List<String> namespaces = [];
 
   @override
@@ -32,7 +35,10 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
       sb.write(':deviceName:$deviceName');
     }
     if (namespaces.isNotEmpty) {
-      sb.write(':namespaces:${namespaces.join(';')}');
+      sb.write(':namespaces:[${namespaces.join(';')}]');
+    }
+    if (totp != null) {
+      sb.write(':totp:${totp.toString()}');
     }
     if (apkamPublicKey != null) {
       sb.write(':apkamPublicKey:$apkamPublicKey');
@@ -48,6 +54,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
     return appName != null &&
         deviceName != null &&
         namespaces.isNotEmpty &&
+        totp != null &&
         apkamPublicKey != null;
   }
 }

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -1,4 +1,5 @@
 import 'package:at_commons/src/verb/abstract_verb_builder.dart';
+import 'package:meta/meta.dart';
 
 import 'operation_enum.dart';
 
@@ -17,6 +18,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
   String? apkamPublicKey;
 
   /// totp for the enroll request. totp must be fetched from an already enrolled app.
+  @experimental
   int? totp;
 
   List<String> namespaces = [];

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -7,7 +7,7 @@ class VerbSyntax {
   static const pol = r'^pol$';
   static const cram = r'^cram:(?<digest>.+$)';
   static const pkam =
-      r'^pkam:(signingAlgo:(?<signingAlgo>ecc_secp256r1|rsa2048):)?(hashingAlgo:(?<hashingAlgo>sha256):)?(?<signature>.+$)';
+      r'^pkam:(signingAlgo:(?<signingAlgo>ecc_secp256r1|rsa2048):)?(hashingAlgo:(?<hashingAlgo>sha256):)?(enrollApprovalId:(?<enrollApprovalId>.+):)?(?<signature>.+$)';
   static const llookup = r'^llookup'
       r'(:(?<operation>meta|all))?'
       r'(:cached)?'
@@ -126,5 +126,6 @@ class VerbSyntax {
   static const noOp = r'^noop:(?<delayMillis>\d+)$';
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
   static const enroll =
-      r'^enroll:(?<operation>request|approve|deny)(:appName:(?<appName>(\w+)))(:deviceName:(?<deviceName>(\w+)))(:namespaces:(?<namespaces>(.*(?:;.*)*)))(:apkamPublicKey:(?<apkamPublicKey>.*))$';
+      r'^enroll:(?<operation>request|approve|deny):(?:(?:enrollmentId:(?<enrollmentId>[a-zA-Z0-9-]+))|(?:appName:(?<appName>[a-zA-Z0-9]+):)?(?:deviceName:(?<deviceName>[a-zA-Z0-9_]+):)?(?:namespaces:\[(?<namespaces>[a-zA-Z0-9;_,]+)\]:)?(?:totp:(?<totp>[0-9]+):)?(?:apkamPublicKey:(?<apkamPublicKey>.*)))?$';
+  static const totp = r'^totp:(?<operation>get|validate)(:(?<totp>[0-9]+))?$';
 }

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.47
+version: 3.0.48
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/enroll_verb_builder_test.dart
+++ b/packages/at_commons/test/enroll_verb_builder_test.dart
@@ -13,7 +13,7 @@ void main() {
         ..apkamPublicKey = 'abcd1234';
       var command = enrollVerbBuilder.buildCommand();
       expect(command,
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:wavi,rw;__manage,rw:apkamPublicKey:abcd1234\n');
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:[wavi,rw;__manage,r]:apkamPublicKey:abcd1234\n');
     });
     test('enroll verb - check enroll approve build command', () {
       var enrollVerbBuilder = EnrollVerbBuilder()
@@ -24,18 +24,19 @@ void main() {
         ..apkamPublicKey = 'abcd1234';
       var command = enrollVerbBuilder.buildCommand();
       expect(command,
-          'enroll:approve:appName:wavi:deviceName:pixel:namespaces:wavi,rw:apkamPublicKey:abcd1234\n');
+          'enroll:approve:appName:wavi:deviceName:pixel:namespaces:[wavi,rw]:apkamPublicKey:abcd1234\n');
     });
     test('enroll verb - check enroll deny build command', () {
       var enrollVerbBuilder = EnrollVerbBuilder()
         ..operation = EnrollOperationEnum.approve
         ..appName = 'wavi'
         ..deviceName = 'pixel'
+        ..totp = 3446
         ..namespaces = ['wavi,rw', '__manage,r']
         ..apkamPublicKey = 'abcd1234';
       var command = enrollVerbBuilder.buildCommand();
       expect(command,
-          'enroll:approve:appName:wavi:deviceName:pixel:namespaces:wavi,rw;__manage,r:apkamPublicKey:abcd1234\n');
+          'enroll:approve:appName:wavi:deviceName:pixel:namespaces:[wavi,rw;__manage,r]:totp:3446:apkamPublicKey:abcd1234\n');
     });
 
     test('enroll verb - check enroll request verb params', () {
@@ -44,15 +45,22 @@ void main() {
         ..appName = 'wavi'
         ..deviceName = 'pixel'
         ..namespaces = ['wavi,rw', '__manage,r']
+        ..totp = 1234
         ..apkamPublicKey = 'abcd1234';
 
       var command = enrollVerbBuilder.buildCommand();
-      var params = VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim())!;
-      expect(params['operation'], 'request');
-      expect(params['appName'], 'wavi');
-      expect(params['deviceName'], 'pixel');
-      expect(params['namespaces'], 'wavi,rw;__manage,r');
-      expect(params['apkamPublicKey'], 'abcd1234');
+      print(command);
+      try {
+        var params = VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim())!;
+        expect(params['operation'], 'request');
+        expect(params['appName'], 'wavi');
+        expect(params['deviceName'], 'pixel');
+        expect(params['namespaces'], 'wavi,rw;__manage,r');
+        expect(params['totp'], '1234');
+        expect(params['apkamPublicKey'], 'abcd1234');
+      } catch(e, trace) {
+        print(trace);
+      }
     });
 
     test('enroll verb - invalid syntax - no app name', () {
@@ -72,8 +80,8 @@ void main() {
     test('enroll verb - invalid syntax - no namespace', () {
       var command =
           'enroll:request:appName:wavi:deviceName:pixel:apkamPublicKey:abcd1234';
-      var params = VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim());
-      expect(params, null);
+      var params = VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim())!;
+      expect(params['namespaces'], null);
     });
     test('enroll verb - invalid syntax - no apkam public key', () {
       var command =

--- a/packages/at_commons/test/enroll_verb_builder_test.dart
+++ b/packages/at_commons/test/enroll_verb_builder_test.dart
@@ -13,7 +13,7 @@ void main() {
         ..apkamPublicKey = 'abcd1234';
       var command = enrollVerbBuilder.buildCommand();
       expect(command,
-          'enroll:request:appName:wavi:deviceName:pixel:namespaces:wavi,rw;__manage,r:apkamPublicKey:abcd1234\n');
+          'enroll:request:appName:wavi:deviceName:pixel:namespaces:wavi,rw;__manage,rw:apkamPublicKey:abcd1234\n');
     });
     test('enroll verb - check enroll approve build command', () {
       var enrollVerbBuilder = EnrollVerbBuilder()


### PR DESCRIPTION
**- What I did**
- added totp support in enroll verb
**- How I did it**
- added a param totp in enroll verb syntax
- modified tests in enroll_verb_builder_test.dart
- temporarily introduced syntax for totp verb. This may change based on arch call discussion.
**- How to verify it**
- run the unit tests enroll_verb_builder_test.dart
