### PR TITLE
fix: Add default logging handler

### DIFF
--- a/packages/at_utils/lib/src/logging/atsignlogger.dart
+++ b/packages/at_utils/lib/src/logging/atsignlogger.dart
@@ -16,14 +16,37 @@ class AtSignLogger {
   static final StdErrLoggingHandler _stdErrLoggingHandler =
       StdErrLoggingHandler();
 
+  /// Represents the default loggingType.
+  /// Supported types are Console and StandardError.
+  ///
+  /// To set the default log type to StandardError
+  /// ```dart
+  ///  AtSignLogger.defaultLoggingType = LoggingType.stdErr
+  /// ```
+  ///
+  /// To set the default log type to Console
+  /// ```dart
+  /// AtSignLogger.defaultLoggingType = LoggingType.console
+  /// ```
+  /// The default log type is LoggingType.console which logs to console.
+  ///
+  static LoggingType defaultLoggingType = LoggingType.console;
+
   /// The AtSignLogger is a wrapper on the Logger to log events.
   ///
   /// * name: Accepts String as input which represents the name of the AtSignLogger instance.
   ///
-  /// * loggingType: This is an optionally parameter which specifies where to log
-  /// the events. Supported types are Console and StandardError.
-  /// The default loggingType is set to console which writes log messages to console.
-  AtSignLogger(String name, {LoggingType loggingType = LoggingType.console}) {
+  /// * loggingType: This is an optional parameter that determines the destination for logging events.
+  /// If the loggingType is not provided it will default to the value of [defaultLoggingType].
+  ///
+  ///  The supported LoggingTypes are:
+  ///
+  ///  * [LoggingType.Console] : Logging events with this type will be displayed in the console or command line where the program is running.
+  ///
+  ///  * [LoggingType.stdErr] : Logging events with this type will be sent to the standard error stream, which is typically displayed separately from the standard output.
+  ///
+  AtSignLogger(String name, {LoggingType? loggingType}) {
+    loggingType ??= defaultLoggingType;
     LoggingHandler loggingHandler = _getLoggingHandler(loggingType);
     logger = logging.Logger.detached(name);
     logger.onRecord.listen(loggingHandler);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Ability to set the default log level to "stdErr"

**- How I did it**
* Introduce a static field - defaultLoggingType, which holds the default log type. When the loggingType in the AtSignLogger constructor is not set, the defaultLoggingType is considered.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->