### PR TITLE
feat: introduce AtResetException for AtClient

### DIFF
--- a/packages/at_commons/lib/src/exception/at_client_exceptions.dart
+++ b/packages/at_commons/lib/src/exception/at_client_exceptions.dart
@@ -74,3 +74,10 @@ class AtKeyNotFoundException extends AtClientException {
       : super.message(message,
             intent: intent, exceptionScenario: exceptionScenario);
 }
+
+class AtResetException extends AtClientException {
+  AtResetException(String message,
+      {Intent? intent, ExceptionScenario? exceptionScenario})
+      : super.message(message,
+      intent: intent, exceptionScenario: exceptionScenario);
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Introduce a new exception that can be thrown when the client identifies that a remote secondary has been reset

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- feat: introduce AtResetException for AtClient