### PR TITLE
fix: Work around breaking change in encrypt package 5.0.2

### DIFF
--- a/packages/at_cli/CHANGELOG.md
+++ b/packages/at_cli/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.1.2
+- work around a breaking change in `encrypt` package 5.0.2
 ## 3.1.1
 - Released pub global binary
 ## 3.1.0

--- a/packages/at_cli/lib/src/at_cli.dart
+++ b/packages/at_cli/lib/src/at_cli.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:args/args.dart';
 import 'package:at_cli/src/command_line_parser.dart';
 import 'package:at_client/at_client.dart';
@@ -206,7 +207,7 @@ class AtCli {
   String decryptValue(String encryptedValue, String decryptionKey) {
     var aesKey = AES(Key.fromBase64(decryptionKey));
     var decrypter = Encrypter(aesKey);
-    var iv2 = IV.fromLength(16);
+    var iv2 = IV(Uint8List(16));
     return decrypter.decrypt64(encryptedValue, iv: iv2);
   }
 

--- a/packages/at_cli/pubspec.yaml
+++ b/packages/at_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_cli
 description: A command line utility for at protocol commands.
-version: 3.1.1
+version: 3.1.2
 repository: https://github.com/atsign-foundation/at_tools
 homepage: https://atsign.dev
 

--- a/packages/at_dump_atKeys/CHANGELOG.md
+++ b/packages/at_dump_atKeys/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.1
+- work around a breaking change in `encrypt` package 5.0.2
+
 ## 1.0.0
 
 - Initial version, derived from PKAM tool

--- a/packages/at_dump_atKeys/bin/generate_at_demo_data.dart
+++ b/packages/at_dump_atKeys/bin/generate_at_demo_data.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:args/args.dart';
 import 'package:at_dump_atKeys/commandline_parser.dart';
@@ -138,6 +139,6 @@ ArgParser getArgParser() {
 String decryptValue(String encryptedValue, String decryptionKey) {
   var aesKey = AES(Key.fromBase64(decryptionKey));
   var decrypter = Encrypter(aesKey);
-  var iv2 = IV.fromLength(16);
+  var iv2 = IV(Uint8List(16));
   return decrypter.decrypt64(encryptedValue, iv: iv2);
 }

--- a/packages/at_dump_atKeys/bin/main.dart
+++ b/packages/at_dump_atKeys/bin/main.dart
@@ -49,6 +49,6 @@ Future<void> main(List<String> arguments) async {
 String decryptValue(String encryptedValue, String decryptionKey) {
   var aesKey = AES(Key.fromBase64(decryptionKey));
   var decrypter = Encrypter(aesKey);
-  var iv2 = IV.fromLength(16);
+  var iv2 = IV(Uint8List(16));
   return decrypter.decrypt64(encryptedValue, iv: iv2);
 }

--- a/packages/at_dump_atKeys/pubspec.yaml
+++ b/packages/at_dump_atKeys/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_dump_atKeys
 description: A command-line utility to dump keys from an atKeys file
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: '>=2.12.0 <4.0.0'

--- a/packages/at_pkam/CHANGELOG.md
+++ b/packages/at_pkam/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.2
+- work around a breaking change in `encrypt` package 5.0.2
+
 ## 1.1.1
 
 - Released pub global binary

--- a/packages/at_pkam/bin/main.dart
+++ b/packages/at_pkam/bin/main.dart
@@ -101,6 +101,6 @@ Future<String?> getSecretFromZip(String filePath, String aesKeyFilePath) async {
 String decryptValue(String encryptedValue, String decryptionKey) {
   var aesKey = AES(Key.fromBase64(decryptionKey));
   var decrypter = Encrypter(aesKey);
-  var iv2 = IV.fromLength(16);
+  var iv2 = IV(Uint8List(16));
   return decrypter.decrypt64(encryptedValue, iv: iv2);
 }

--- a/packages/at_pkam/pubspec.yaml
+++ b/packages/at_pkam/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_pkam
 description: A command-line utility to generate PKAM digest
-version: 1.1.1
+version: 1.1.2
 repository: https://github.com/atsign-foundation/at_tools
 
 executables:


### PR DESCRIPTION
Will need to publish new versions of at_cli and at_pkam packages

**- What I did**
fix: where we were using encrypt package's `IV.fromLength(16)` to generate empty IVs, we now need to use IV(Uint8List(16)) as encrypt package 5.0.2 has changed the behaviour of `IV.fromLength`

**- How I did it**

**- How to verify it**
