### PR TITLE
chore: add build-tools command to quickly build stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ build/
 pubspec.lock
 pubspec_overrides.yaml
 
+build-tools/
+
 # Directory created by dartdoc
 # If you don't generate documentation locally you can remove this line.
 doc/api/

--- a/README.md
+++ b/README.md
@@ -26,3 +26,23 @@ atProtocol.
 [at_ve_doctor](./packages/at_ve_doctor) A very simple way to test the status of the
 secondaries running in the Virtual Environment. Using the
 [at_server_status](https://pub.dev/packages/at_server_status) package.
+
+### Quickly build tools
+
+Using melos, we can quickly build at_pkam, at_cram, at_cli, and at_repl via the
+following commands:
+
+```bash
+dart pub get
+dart run melos run build-tools
+```
+
+Then move the tools to a folder which you've exposed to the path for
+convenience, for example:
+
+```
+cp ./build-tools/* ~/.local/bin/
+# or
+sudo cp ./build-tools/* /usr/local/bin/
+```
+

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dart run melos run build-tools
 Then move the tools to a folder which you've exposed to the path for
 convenience, for example:
 
-```
+```bash
 cp ./build-tools/* ~/.local/bin/
 # or
 sudo cp ./build-tools/* /usr/local/bin/

--- a/melos.yaml
+++ b/melos.yaml
@@ -2,3 +2,6 @@ name: at_tools
 
 packages:
   - packages/**
+
+scripts:
+  build-tools: ./tools/build-tools.sh

--- a/tools/build-tools.sh
+++ b/tools/build-tools.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+script_dir="$(dirname -- "$(readlink -f -- "$0")")"
+cd "$script_dir/.." || exit 1 # cd to root of repo
+
+melos bootstrap --scope=at_cli --scope=at_cram --scope=at_pkam --scope=at_repl
+
+mkdir -p build-tools
+
+dart compile exe packages/at_cli/bin/main.dart -o build-tools/at_cli
+dart compile exe packages/at_cram/bin/at_cram.dart -o build-tools/at_cram
+dart compile exe packages/at_pkam/bin/main.dart -o build-tools/at_pkam
+dart compile exe packages/at_repl/bin/at_repl.dart -o build-tools/at_repl


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

quick bash script which builds, can also be invoked via `melos run build-tools`:
- at_repl
- at_cli
- at_cram
- at_pkam


**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: add build-tools command to quickly build stuff
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
